### PR TITLE
docs: highlight agent-assisted installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ A project can stop, resume, survive a runtime replacement, and continue from its
 - Node.js 22+
 - One supported Agent CLI installed and authenticated through its official login flow
 
-### Agent-assisted installation
+### 🚀 Agent-assisted installation (recommended)
 
-Send this prompt to Codex CLI, Claude Code, GitHub Copilot CLI, Pi, or
-OpenCode. The agent will inspect the environment, install Argus, connect the
-current backend, and verify it with `argus --doctor`:
+> [!TIP]
+> **Skip the manual installation steps.** Send the complete prompt below to
+> Codex CLI, Claude Code, GitHub Copilot CLI, Pi, or OpenCode. The agent will
+> inspect the environment, install Argus, connect the current backend, and
+> verify it with `argus --doctor`.
 
 ```text
 Read https://github.com/lbx154/Argus/blob/main/docs/agent-install.md and follow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,11 +57,12 @@
 - Node.js 22+
 - 至少一个已按官方方式安装并完成登录鉴权的 Agent CLI
 
-### Agent 一键接入
+### 🚀 Agent 一键接入（推荐）
 
-将下面这句话发送给 Codex CLI、Claude Code、GitHub Copilot CLI、Pi 或
-OpenCode，Agent 会检查环境、安装 Argus、连接当前 backend，并运行
-`argus --doctor` 验收：
+> [!TIP]
+> **无需手动逐条安装。** 将下面整段提示词发送给 Codex CLI、Claude Code、
+> GitHub Copilot CLI、Pi 或 OpenCode。Agent 会检查环境、安装 Argus、连接当前
+> backend，并运行 `argus --doctor` 验收。
 
 ```text
 请阅读 https://github.com/lbx154/Argus/blob/main/docs/agent-install.md，


### PR DESCRIPTION
## Summary

- highlight the agent-assisted installation entry with GitHub TIP callouts
- mark the flow as recommended in both English and Chinese READMEs
- keep the copyable prompts unchanged