### PR TITLE
feat: add Grok Build as a first-class agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ argus --setup --non-interactive \
   --accept-house-rules
 ```
 
-Use `copilot`, `pi`, `codex`, `claude`, or `opencode` for `--backend`.
+Use `copilot`, `pi`, `codex`, `claude`, `opencode`, or `grok` for `--backend`.
 
 #### Choosing a provider on the multi-provider CLIs
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,7 +96,7 @@ argus --setup --non-interactive \
   --accept-house-rules
 ```
 
-`--backend` 可使用 `copilot`、`pi`、`codex`、`claude` 或 `opencode`。
+`--backend` 可使用 `copilot`、`pi`、`codex`、`claude`、`opencode` 或 `grok`。
 
 #### 为多 provider 的 CLI 指定 provider
 

--- a/argus_skill/adapters/agent_cli_backend/_core.py
+++ b/argus_skill/adapters/agent_cli_backend/_core.py
@@ -52,7 +52,7 @@ class AgentCliBackend:
     """``RunnerBackend`` implementation that shells out to a real CLI.
 
     Construct once with the runner backend choice ("codex" / "claude" /
-    "copilot" / "opencode" / "pi") and any cross-call defaults (e.g. ``default_extra_args``
+    "copilot" / "opencode" / "pi" / "grok") and any cross-call defaults (e.g. ``default_extra_args``
     for ``-c "config_profile=..."``), then pass the same instance to
     every ``SkillLoop`` actor (author / engineer / reviewer). Each
     ``run_exec`` call spawns a fresh subprocess.
@@ -65,10 +65,10 @@ class AgentCliBackend:
     enough).
 
     Args:
-        backend: which CLI to drive ("codex" / "claude" / "copilot" / "opencode" / "pi").
+        backend: which CLI to drive ("codex" / "claude" / "copilot" / "opencode" / "pi" / "grok").
             Defaults to the bundled runner's default (codex).
         runner_bin: explicit path to the CLI binary. Default: resolve
-            from ``$PATH`` (e.g. ``codex`` / ``claude`` / ``copilot`` / ``opencode`` / ``pi``).
+            from ``$PATH`` (e.g. ``codex`` / ``claude`` / ``copilot`` / ``opencode`` / ``pi`` / ``grok``).
         default_extra_args: appended to every command (after
             ``options.extra_args``). Useful for global ``-c`` flags.
         before_exec: called before each subprocess spawn — used to reset

--- a/argus_skill/agent_cli/_event_consumers.py
+++ b/argus_skill/agent_cli/_event_consumers.py
@@ -7,7 +7,13 @@ from __future__ import annotations
 
 import json
 
-from .runner_backend import BACKEND_CLAUDE, BACKEND_COPILOT, BACKEND_OPENCODE, BACKEND_PI
+from .runner_backend import (
+    BACKEND_CLAUDE,
+    BACKEND_COPILOT,
+    BACKEND_GROK,
+    BACKEND_OPENCODE,
+    BACKEND_PI,
+)
 
 
 class EventConsumerMixin:
@@ -110,6 +116,17 @@ class EventConsumerMixin:
         fatal_error: str | None,
     ) -> tuple[str | None, bool, bool, str | None]:
         if self.backend == BACKEND_CLAUDE:
+            return self._consume_claude_event(
+                event=event,
+                thread_id=thread_id,
+                agent_messages=agent_messages,
+                turn_completed=turn_completed,
+                turn_failed=turn_failed,
+                fatal_error=fatal_error,
+            )
+        if self.backend == BACKEND_GROK:
+            # Grok --output-format streaming-messages-json matches the Claude
+            # Messages NDJSON dialect (assistant / result events).
             return self._consume_claude_event(
                 event=event,
                 thread_id=thread_id,

--- a/argus_skill/agent_cli/_prompt_delivery.py
+++ b/argus_skill/agent_cli/_prompt_delivery.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import tempfile
+from pathlib import Path
 
 from ..core.sandbox import sandboxed_child_env
 from ._sandbox_commands import (
@@ -14,6 +16,7 @@ from .copilot_home import apply_copilot_home
 from .runner_backend import (
     BACKEND_CLAUDE,
     BACKEND_COPILOT,
+    BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
 )
@@ -125,11 +128,66 @@ class PromptDeliveryMixin:
         except OSError:
             return
 
+    def _cleanup_ephemeral_prompt_files(self) -> None:
+        """Remove temporary prompt files written for backends such as Grok."""
+        paths = getattr(self, "_ephemeral_prompt_files", None)
+        if not paths:
+            return
+        remaining: list[str] = []
+        for raw in paths:
+            try:
+                Path(raw).unlink(missing_ok=True)
+            except OSError:
+                remaining.append(raw)
+        self._ephemeral_prompt_files = remaining
+
+    def _write_grok_prompt_file(self, prompt: str) -> str:
+        """Persist the role prompt for ``grok --prompt-file`` delivery."""
+        try:
+            from ..core.paths import global_root
+
+            directory = global_root() / "tmp"
+            directory.mkdir(parents=True, exist_ok=True)
+            fd, path = tempfile.mkstemp(
+                prefix="grok-prompt-",
+                suffix=".txt",
+                dir=str(directory),
+            )
+        except OSError:
+            fd, path = tempfile.mkstemp(prefix="grok-prompt-", suffix=".txt")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(prompt)
+                if not prompt.endswith("\n"):
+                    handle.write("\n")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                Path(path).unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+        files = getattr(self, "_ephemeral_prompt_files", None)
+        if files is None:
+            self._ephemeral_prompt_files = [path]
+        else:
+            files.append(path)
+        return path
+
     def _prepare_prompt_delivery(
         self,
         command: list[str],
         prompt: str,
     ) -> tuple[list[str], str | None]:
+        if self.backend == BACKEND_GROK:
+            prepared = list(command)
+            path = self._write_grok_prompt_file(prompt)
+            prepared.extend(["--prompt-file", path])
+            # Prompt lives on disk; close stdin without writing it.
+            return prepared, None
         if self.backend != BACKEND_CLAUDE:
             return command, prompt
         prepared = list(command)

--- a/argus_skill/agent_cli/_run_exec.py
+++ b/argus_skill/agent_cli/_run_exec.py
@@ -87,37 +87,44 @@ class RunExecMixin:
     ) -> AgentRunResult:
         if self.before_exec is not None:
             self.before_exec()
-        gated = self._run_exec_start_gate(resume_thread_id=resume_thread_id, options=options)
-        if gated is not None:
-            return gated
-        # Warm-copilot fast path: Manager front-door classify + direct replies go
-        # through a persistent ``copilot --acp`` process.  The ACP client keeps
-        # the classifier and conversation in separate logical sessions.
-        if self._acp_enabled(run_label, options):
-            acp_result = self._run_exec_acp(
-                prompt=prompt,
-                resume_thread_id=resume_thread_id,
+        try:
+            gated = self._run_exec_start_gate(
+                resume_thread_id=resume_thread_id, options=options
+            )
+            if gated is not None:
+                return gated
+            # Warm-copilot fast path: Manager front-door classify + direct replies go
+            # through a persistent ``copilot --acp`` process.  The ACP client keeps
+            # the classifier and conversation in separate logical sessions.
+            if self._acp_enabled(run_label, options):
+                acp_result = self._run_exec_acp(
+                    prompt=prompt,
+                    resume_thread_id=resume_thread_id,
+                    options=options,
+                    run_label=run_label,
+                )
+                if acp_result is not None:
+                    return acp_result
+            options = self._apply_sandbox_policy(options)
+            command, process, spawn_failure = self._spawn_turn_process(
+                prompt=prompt, resume_thread_id=resume_thread_id, options=options
+            )
+            if spawn_failure is not None:
+                return spawn_failure
+            state = self._stream_turn_output(
+                process=process,
+                command=command,
                 options=options,
                 run_label=run_label,
+                thread_id=resume_thread_id,
             )
-            if acp_result is not None:
-                return acp_result
-        options = self._apply_sandbox_policy(options)
-        command, process, spawn_failure = self._spawn_turn_process(
-            prompt=prompt, resume_thread_id=resume_thread_id, options=options
-        )
-        if spawn_failure is not None:
-            return spawn_failure
-        state = self._stream_turn_output(
-            process=process,
-            command=command,
-            options=options,
-            run_label=run_label,
-            thread_id=resume_thread_id,
-        )
-        return self._finalize_turn_result(
-            process=process, command=command, options=options, state=state
-        )
+            return self._finalize_turn_result(
+                process=process, command=command, options=options, state=state
+            )
+        finally:
+            cleanup = getattr(self, "_cleanup_ephemeral_prompt_files", None)
+            if callable(cleanup):
+                cleanup()
 
     @classmethod
     def _cleanup_orphan_process_group(

--- a/argus_skill/agent_cli/_sandbox_commands.py
+++ b/argus_skill/agent_cli/_sandbox_commands.py
@@ -18,6 +18,7 @@ from .runner_backend import (
     BACKEND_CLAUDE,
     BACKEND_CODEX,
     BACKEND_COPILOT,
+    BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
     RunnerBackend,
@@ -247,6 +248,10 @@ class CommandBuilderMixin:
             return self._build_pi_command(
                 resume_thread_id=resume_thread_id, options=options
             )
+        if self.backend == BACKEND_GROK:
+            return self._build_grok_command(
+                resume_thread_id=resume_thread_id, options=options
+            )
         return self._build_codex_command(resume_thread_id=resume_thread_id, options=options)
 
     def _apply_sandbox_policy(self, options):
@@ -269,6 +274,7 @@ class CommandBuilderMixin:
             BACKEND_COPILOT,
             BACKEND_OPENCODE,
             BACKEND_PI,
+            BACKEND_GROK,
         ):
             return options
         if options.sandbox_mode is not None:
@@ -579,4 +585,49 @@ class CommandBuilderMixin:
             command.extend(["--session", resume_thread_id])
         # Pi reads non-TTY stdin into the initial message in JSON mode. Keeping
         # the prompt out of argv avoids E2BIG and process-list disclosure.
+        return command
+
+    def _build_grok_command(
+        self,
+        *,
+        resume_thread_id: str | None,
+        options,
+    ) -> list[str]:
+        """Build a Grok Build headless turn.
+
+        Prompt text is injected later via ``--prompt-file`` in
+        ``_prepare_prompt_delivery`` so large role prompts never hit ARG_MAX.
+        Stream format reuses the Claude-compatible Messages NDJSON dialect.
+        """
+        command = [
+            self.agent_bin,
+            "--output-format",
+            "streaming-messages-json",
+            "--no-auto-update",
+        ]
+        if options.model:
+            command.extend(["--model", options.model])
+        if options.reasoning_effort:
+            command.extend(["--reasoning-effort", options.reasoning_effort])
+        if options.working_dir:
+            command.extend(["--cwd", options.working_dir])
+        if options.sandbox_mode == "read-only":
+            # Tool ids from Grok's headless init payload (not Claude names).
+            command.extend(["--tools", "read_file,grep,list_dir"])
+        elif options.dangerous_yolo:
+            command.extend(["--permission-mode", "bypassPermissions"])
+        elif options.full_auto:
+            command.extend(["--permission-mode", "acceptEdits"])
+        merged_extra_args = [*self.default_extra_args]
+        if options.extra_args:
+            merged_extra_args.extend(options.extra_args)
+        if options.sandbox_mode == "read-only":
+            merged_extra_args = _read_only_extra_args(
+                merged_extra_args,
+                backend=BACKEND_GROK,
+            )
+        if merged_extra_args:
+            command.extend(merged_extra_args)
+        if resume_thread_id:
+            command.extend(["--resume", resume_thread_id])
         return command

--- a/argus_skill/agent_cli/agent_cli_runner.py
+++ b/argus_skill/agent_cli/agent_cli_runner.py
@@ -1,4 +1,4 @@
-"""Vendored low-level codex/claude/copilot/opencode/pi CLI driver.
+"""Vendored low-level codex/claude/copilot/opencode/pi/grok CLI driver.
 
 ``AgentCliRunner`` and ``RunnerOptions`` are the two public names callers
 import from this module (``argus_skill.adapters.agent_cli_backend`` wraps
@@ -94,7 +94,7 @@ class AgentCliRunner(
     OpenCodeRecoveryMixin,
     ProcessControlMixin,
 ):
-    """Drives one codex/claude/copilot/opencode/pi CLI turn.
+    """Drives one codex/claude/copilot/opencode/pi/grok CLI turn.
 
     This class itself only owns construction and ACP-scope state; every other
     behavior comes from the mixins above (each documented in its own module):

--- a/argus_skill/agent_cli/runner_backend.py
+++ b/argus_skill/agent_cli/runner_backend.py
@@ -5,18 +5,19 @@ import shutil
 from pathlib import Path
 from typing import Literal
 
-RunnerBackend = Literal["codex", "claude", "copilot", "opencode", "pi"]
+RunnerBackend = Literal["codex", "claude", "copilot", "opencode", "pi", "grok"]
 
 BACKEND_CODEX: RunnerBackend = "codex"
 BACKEND_CLAUDE: RunnerBackend = "claude"
 BACKEND_COPILOT: RunnerBackend = "copilot"
 BACKEND_OPENCODE: RunnerBackend = "opencode"
 BACKEND_PI: RunnerBackend = "pi"
+BACKEND_GROK: RunnerBackend = "grok"
 DEFAULT_RUNNER_BACKEND: RunnerBackend = BACKEND_CODEX
 
 
 def normalize_runner_backend(raw: str | None) -> RunnerBackend:
-    value = str(raw or "").strip().lower()
+    value = str(raw or "").strip().lower().replace("_", "-")
     if value == BACKEND_CLAUDE:
         return BACKEND_CLAUDE
     if value == BACKEND_COPILOT:
@@ -25,6 +26,8 @@ def normalize_runner_backend(raw: str | None) -> RunnerBackend:
         return BACKEND_OPENCODE
     if value == BACKEND_PI:
         return BACKEND_PI
+    if value in (BACKEND_GROK, "grok-build"):
+        return BACKEND_GROK
     return BACKEND_CODEX
 
 
@@ -37,6 +40,8 @@ def default_runner_bin(backend: RunnerBackend) -> str:
         return "opencode"
     if backend == BACKEND_PI:
         return "pi"
+    if backend == BACKEND_GROK:
+        return "grok"
     return "codex"
 
 
@@ -59,6 +64,10 @@ def resolve_runner_bin(
         opencode_home = Path.home() / ".opencode" / "bin" / expanded
         if opencode_home.is_file() and os.access(opencode_home, os.X_OK):
             return str(opencode_home)
+    if chosen == BACKEND_GROK:
+        grok_home = Path.home() / ".grok" / "bin" / expanded
+        if grok_home.is_file() and os.access(grok_home, os.X_OK):
+            return str(grok_home)
     user_local = Path.home() / ".local" / "bin" / expanded
     if user_local.is_file() and os.access(user_local, os.X_OK):
         return str(user_local)

--- a/argus_skill/apps/_life_actions.py
+++ b/argus_skill/apps/_life_actions.py
@@ -11,7 +11,7 @@ from typing import Any, Mapping, Sequence
 
 from ..life import BacklogItem
 
-_LIFE_BACKENDS = ("codex", "claude", "copilot", "opencode", "pi", "memory")
+_LIFE_BACKENDS = ("codex", "claude", "copilot", "opencode", "pi", "grok", "memory")
 
 
 def format_backlog_list(mem: Any, *, include_all: bool) -> str:
@@ -354,6 +354,8 @@ def render_backend_cmd(tokens: Sequence[str], chat_state: dict[str, Any]) -> str
     new = tokens[0].lower()
     if new == "opencod":
         new = "opencode"
+    if new in {"grok-build", "grok_build"}:
+        new = "grok"
     if new in _LIFE_BACKENDS:
         state = chat_state.get("continuous_state")
         if isinstance(state, ContinuousConfigState):

--- a/argus_skill/apps/_runtime_construction.py
+++ b/argus_skill/apps/_runtime_construction.py
@@ -522,7 +522,7 @@ def _resolve_runner_backend_name(
     if explicit:
         return explicit
     resolved = getattr(args, "backend", None)
-    if resolved in ("codex", "claude", "copilot", "opencode", "pi"):
+    if resolved in ("codex", "claude", "copilot", "opencode", "pi", "grok"):
         return resolved
     return None
 
@@ -564,7 +564,7 @@ def build_life_runner(args: argparse.Namespace, *, seed_thread_id: str | None = 
         if scripted_backend is not None:
             runner.backend = scripted_backend
         return runner
-    if args.backend in ("codex", "claude", "copilot", "opencode", "pi"):
+    if args.backend in ("codex", "claude", "copilot", "opencode", "pi", "grok"):
         # These are agent-CLI backends: _SkillLoopRunner drives the selected
         # CLI via AgentCliBackend (per-role resolution), so the
         # SAME runner serves every backend. Gating this on "codex" alone used to

--- a/argus_skill/apps/cli/_parser.py
+++ b/argus_skill/apps/cli/_parser.py
@@ -271,7 +271,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     capability_grp.add_argument(
         "--backend",
-        choices=("copilot", "codex", "claude", "opencode", "pi"),
+        choices=("copilot", "codex", "claude", "opencode", "pi", "grok"),
         default=None,
         help="backend selected by --setup, --doctor, or this daemon launch",
     )

--- a/argus_skill/core/backend_readiness.py
+++ b/argus_skill/core/backend_readiness.py
@@ -27,14 +27,19 @@ SETUP_EXIT_USAGE = 2
 SETUP_EXIT_NOT_READY = 3
 SETUP_EXIT_PERSISTENCE = 4
 
-_SUPPORTED_BACKENDS = frozenset({"codex", "copilot", "claude", "opencode", "pi"})
+_SUPPORTED_BACKENDS = frozenset(
+    {"codex", "copilot", "claude", "opencode", "pi", "grok"}
+)
 _VERSION_RE = re.compile(
     r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?"
 )
+# Also accept two-part versions such as "grok 1.0.0" or bare "1.0".
+_VERSION_RE_LOOSE = re.compile(r"(?<!\d)(\d+)\.(\d+)(?:\.(\d+))?(?:[-+]([0-9A-Za-z.-]+))?")
 _AUTH_COMMANDS: dict[str, tuple[str, ...]] = {
     "codex": ("login", "status"),
     "claude": ("auth", "status"),
     "opencode": ("auth", "list"),
+    "grok": ("models",),
 }
 _INSTALL_COMMANDS = {
     "codex": "npm install -g @openai/codex@latest",
@@ -42,6 +47,7 @@ _INSTALL_COMMANDS = {
     "claude": "npm install -g @anthropic-ai/claude-code",
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "pi": "npm install -g --ignore-scripts @earendil-works/pi-coding-agent",
+    "grok": "install the official Grok Build CLI (binary name: grok)",
 }
 _LOGIN_COMMANDS = {
     "codex": "codex login",
@@ -49,6 +55,7 @@ _LOGIN_COMMANDS = {
     "claude": "claude auth login",
     "opencode": "opencode auth login",
     "pi": "pi, then /login",
+    "grok": "grok login",
 }
 
 
@@ -130,7 +137,8 @@ def resolve_backend_profile(
     raw_backend = str(backend_value or "codex").strip().lower()
     normalized_backend = (
         normalize_runner_backend(raw_backend)
-        if raw_backend in _SUPPORTED_BACKENDS or raw_backend == "opencod"
+        if raw_backend in _SUPPORTED_BACKENDS
+        or raw_backend in {"opencod", "grok-build", "grok_build"}
         else raw_backend
     )
 
@@ -177,14 +185,23 @@ def _run_text(
 
 def _extract_version(text: str) -> tuple[str, tuple[int, int, int], str] | None:
     match = _VERSION_RE.search(text)
-    if match is None:
+    if match is not None:
+        version = match.group(0)
+        return (
+            version,
+            (int(match.group(1)), int(match.group(2)), int(match.group(3))),
+            str(match.group(4) or ""),
+        )
+    # Grok prints "grok 1.0.0 (hash)"; accept two- or three-part forms.
+    loose = _VERSION_RE_LOOSE.search(text)
+    if loose is None:
         return None
-    version = match.group(0)
-    return (
-        version,
-        (int(match.group(1)), int(match.group(2)), int(match.group(3))),
-        str(match.group(4) or ""),
-    )
+    major = int(loose.group(1))
+    minor = int(loose.group(2))
+    patch = int(loose.group(3) or 0)
+    prerelease = str(loose.group(4) or "")
+    rendered = f"{major}.{minor}.{patch}" if loose.group(3) is not None else f"{major}.{minor}.0"
+    return rendered, (major, minor, patch), prerelease
 
 
 def _parse_pi_model_catalog(stdout: str) -> dict[str, set[str]]:
@@ -450,7 +467,7 @@ def check_backend_readiness(
             ReadinessProblem(
                 "backend",
                 f"unsupported backend {profile.backend!r}",
-                "choose one of: codex, copilot, claude, opencode, pi",
+                "choose one of: codex, copilot, claude, opencode, pi, grok",
             )
         )
         return report

--- a/argus_skill/core/knobs.py
+++ b/argus_skill/core/knobs.py
@@ -63,7 +63,7 @@ KNOBS: tuple[Knob, ...] = (
     Knob(
         "ARGUS_SKILL_LIFE_BACKEND",
         "codex",
-        "agent backend: codex | copilot | claude | opencode | pi | memory (test only)",
+        "agent backend: codex | copilot | claude | opencode | pi | grok | memory (test only)",
         "backend",
     ),
     Knob("ARGUS_SKILL_RUNNER_BIN", "(agent CLI on PATH)", "absolute path to the agent CLI binary", "backend"),
@@ -421,9 +421,11 @@ def normalize_cockpit_knob_value(name: str, value: str) -> str:
         backend = raw.lower()
         if backend == "opencod":
             backend = "opencode"
-        if backend not in {"codex", "claude", "copilot", "opencode", "pi"}:
+        if backend in {"grok-build", "grok_build"}:
+            backend = "grok"
+        if backend not in {"codex", "claude", "copilot", "opencode", "pi", "grok"}:
             raise ValueError(
-                f"{name} must be codex, claude, copilot, opencode, or pi"
+                f"{name} must be codex, claude, copilot, opencode, pi, or grok"
             )
         return backend
     if name in _EFFORT_KNOBS:
@@ -557,7 +559,7 @@ def resolve_role_model(
 
 
 def resolve_role_backend(role: str, *, env: Mapping[str, str] | None = None) -> str:
-    """Resolve a role's agent-CLI backend (codex / claude / copilot / opencode / pi / memory)
+    """Resolve a role's agent-CLI backend (codex / claude / copilot / opencode / pi / grok / memory)
     using Argus's runtime precedence.
 
     Precedence: role-specific override (``ARGUS_SKILL_<ROLE>_BACKEND``) ->

--- a/argus_skill/core/role_config.py
+++ b/argus_skill/core/role_config.py
@@ -20,6 +20,7 @@ _BACKEND_LABEL = {
     "copilot": "Copilot",
     "opencode": "OpenCode",
     "pi": "Pi",
+    "grok": "Grok Build",
     "memory": "memory",
 }
 
@@ -61,7 +62,7 @@ _ROLE_DESC = {
 @dataclass(frozen=True)
 class RoleConfig:
     role: str
-    backend: str  # normalized: codex / claude / copilot / opencode / pi / memory
+    backend: str  # normalized: codex / claude / copilot / opencode / pi / grok / memory
     backend_label: str  # display: Codex / Claude Code / Copilot / OpenCode / Pi
     model: str
     effort: str | None  # None → not a reasoning model (effort N/A)

--- a/argus_skill/roles/prompts/manager.py
+++ b/argus_skill/roles/prompts/manager.py
@@ -213,7 +213,7 @@ def build_config_intent_prompt(text: str) -> str:
         "Argus has four roles — manager, planner, engineer, reviewer. The "
         "operator-changeable settings are:\n"
         "  PER-ROLE (may name one role, several, or ALL / the shared default):\n"
-        "    backend  — which agent CLI runs a role: codex | claude | copilot | opencode | pi\n"
+        "    backend  — which agent CLI runs a role: codex | claude | copilot | opencode | pi | grok\n"
         "    model    — which model a role calls, e.g. gpt-5.5, claude-sonnet-5, "
         "o3, gemini-3.5 (any id the backend supports)\n"
         "    effort   — a role's reasoning effort: low | medium | high | max | xhigh\n"

--- a/argus_skill/tools/setup.py
+++ b/argus_skill/tools/setup.py
@@ -88,13 +88,21 @@ def _prompt(label: str, default: str = "", secret: bool = False) -> str:
     return val if val else default
 
 
-_SUPPORTED_AGENT_BACKENDS = ("copilot", "codex", "claude", "opencode", "pi")
+_SUPPORTED_AGENT_BACKENDS = (
+    "copilot",
+    "codex",
+    "claude",
+    "opencode",
+    "pi",
+    "grok",
+)
 _BACKEND_INSTALL_COMMANDS = {
     "copilot": "npm install -g @github/copilot",
     "codex": "npm install -g @openai/codex@latest",
     "claude": "npm install -g @anthropic-ai/claude-code",
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "pi": "npm install -g --ignore-scripts @earendil-works/pi-coding-agent",
+    "grok": "install the official Grok Build CLI (binary name: grok)",
 }
 
 
@@ -139,11 +147,15 @@ def _configure_runner_backend(requested: str | None = None) -> str | None:
     selected = (
         str(requested).strip().lower()
         if requested is not None
-        else _prompt("Backend (copilot/codex/claude/opencode/pi)", default).lower()
+        else _prompt(
+            "Backend (copilot/codex/claude/opencode/pi/grok)", default
+        ).lower()
     )
+    if selected in {"grok-build", "grok_build"}:
+        selected = "grok"
     if selected not in _SUPPORTED_AGENT_BACKENDS:
         print(_yellow(f"  Unknown backend '{selected}'."))
-        print(_dim("    Choose one of: copilot, codex, claude, opencode, pi"))
+        print(_dim("    Choose one of: copilot, codex, claude, opencode, pi, grok"))
         print()
         return None
 
@@ -157,6 +169,8 @@ def _configure_runner_backend(requested: str | None = None) -> str | None:
             print(_dim("    Then authenticate with: opencode auth login"))
         elif selected == "pi":
             print(_dim("    Then run `pi` and use `/login` to authenticate."))
+        elif selected == "grok":
+            print(_dim("    Then authenticate with: grok login"))
         print()
         return None
 
@@ -213,10 +227,12 @@ def _run_noninteractive_setup(
     if not backend:
         sys.stderr.write(
             "argus: --setup --non-interactive requires --backend "
-            "{copilot,codex,claude,opencode,pi}\n"
+            "{copilot,codex,claude,opencode,pi,grok}\n"
         )
         return SETUP_EXIT_USAGE
-    selected = str(backend).strip().lower()
+    selected = str(backend).strip().lower().replace("_", "-")
+    if selected == "grok-build":
+        selected = "grok"
     if selected not in _SUPPORTED_AGENT_BACKENDS:
         sys.stderr.write(f"argus: unsupported backend {selected!r}\n")
         return SETUP_EXIT_USAGE

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -39,6 +39,7 @@ command -v codex || true
 command -v claude || true
 command -v pi || true
 command -v opencode || true
+command -v grok || true
 ```
 
 Select the CLI hosting the current conversation when possible. Otherwise,
@@ -52,6 +53,7 @@ values are:
 | Claude Code | `claude` |
 | Pi | `pi` |
 | OpenCode | `opencode` |
+| Grok Build CLI | `grok` |
 
 If prerequisites are missing, explain the proposed installation command and
 obtain approval before using a system package manager, `sudo`, or making a
@@ -101,7 +103,7 @@ From the Argus checkout, run:
 
 ```bash
 .venv/bin/argus --setup --non-interactive \
-  --backend <copilot|codex|claude|pi|opencode> \
+  --backend <copilot|codex|claude|pi|opencode|grok> \
   --accept-house-rules
 ```
 

--- a/tests/test_grok_backend.py
+++ b/tests/test_grok_backend.py
@@ -1,0 +1,203 @@
+"""Unit tests for the Grok Build backend (no live model calls)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from argus_skill.agent_cli.agent_cli_runner import AgentCliRunner, RunnerOptions
+from argus_skill.agent_cli.runner_backend import (
+    BACKEND_GROK,
+    normalize_runner_backend,
+    resolve_runner_bin,
+)
+from argus_skill.core.backend_readiness import (
+    AUTH_MODE_SUBSCRIPTION,
+    check_backend_readiness,
+)
+from argus_skill.core.role_config import resolve_role_config
+
+
+def test_normalize_grok_aliases() -> None:
+    assert normalize_runner_backend("grok") == BACKEND_GROK
+    assert normalize_runner_backend("grok-build") == BACKEND_GROK
+    assert normalize_runner_backend("grok_build") == BACKEND_GROK
+
+
+def test_grok_runner_resolves_standard_install_directory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    executable = tmp_path / ".grok" / "bin" / "grok"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    assert resolve_runner_bin(BACKEND_GROK) == str(executable)
+    assert AgentCliRunner(backend=BACKEND_GROK).agent_bin == str(executable)
+
+
+def test_build_grok_command_yolo_resume_model(tmp_path: Path, monkeypatch) -> None:
+    executable = tmp_path / "grok"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    runner = AgentCliRunner(backend=BACKEND_GROK, agent_bin=str(executable))
+    command = runner._build_command(
+        resume_thread_id="sess-123",
+        options=RunnerOptions(
+            model="grok-4.5",
+            reasoning_effort="high",
+            dangerous_yolo=True,
+            working_dir="/tmp/work",
+        ),
+    )
+    assert command[0] == str(executable)
+    assert "--output-format" in command
+    assert "streaming-messages-json" in command
+    assert command[command.index("--model") + 1] == "grok-4.5"
+    assert command[command.index("--reasoning-effort") + 1] == "high"
+    assert command[command.index("--cwd") + 1] == "/tmp/work"
+    assert command[command.index("--permission-mode") + 1] == "bypassPermissions"
+    assert command[command.index("--resume") + 1] == "sess-123"
+    # Prompt is attached later via --prompt-file, not as -p argv.
+    assert "-p" not in command
+    assert "--prompt-file" not in command
+
+
+def test_build_grok_command_read_only_tools(tmp_path: Path, monkeypatch) -> None:
+    executable = tmp_path / "grok"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    runner = AgentCliRunner(backend=BACKEND_GROK, agent_bin=str(executable))
+    command = runner._build_command(
+        resume_thread_id=None,
+        options=RunnerOptions(sandbox_mode="read-only"),
+    )
+    assert command[command.index("--tools") + 1] == "read_file,grep,list_dir"
+    assert "--permission-mode" not in command
+
+
+def test_prepare_prompt_delivery_uses_prompt_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    executable = tmp_path / "grok"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    runner = AgentCliRunner(backend=BACKEND_GROK, agent_bin=str(executable))
+    base = runner._build_command(
+        resume_thread_id=None,
+        options=RunnerOptions(dangerous_yolo=True),
+    )
+    command, stdin_prompt = runner._prepare_prompt_delivery(base, "hello grok")
+    assert stdin_prompt is None
+    assert "--prompt-file" in command
+    path = Path(command[command.index("--prompt-file") + 1])
+    assert path.is_file()
+    assert path.read_text(encoding="utf-8") == "hello grok\n"
+    runner._cleanup_ephemeral_prompt_files()
+    assert not path.exists()
+
+
+def test_consume_grok_streaming_messages_events() -> None:
+    """Replay a real Grok streaming-messages-json shape without calling the API."""
+    runner = AgentCliRunner(backend=BACKEND_GROK, agent_bin="grok")
+    thread_id = None
+    messages: list[str] = []
+    completed = False
+    failed = False
+    fatal = None
+
+    events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "019fe9a5-5469-73e2-b510-aeb31687e62b",
+        },
+        {
+            "type": "assistant",
+            "session_id": "019fe9a5-5469-73e2-b510-aeb31687e62b",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "OK"}],
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "OK",
+            "session_id": "019fe9a5-5469-73e2-b510-aeb31687e62b",
+        },
+    ]
+    for event in events:
+        thread_id, completed, failed, fatal = runner._consume_event(
+            event=event,
+            thread_id=thread_id,
+            agent_messages=messages,
+            turn_completed=completed,
+            turn_failed=failed,
+            fatal_error=fatal,
+        )
+
+    assert thread_id == "019fe9a5-5469-73e2-b510-aeb31687e62b"
+    assert completed is True
+    assert failed is False
+    assert fatal is None
+    assert messages[-1].strip() == "OK"
+
+
+def test_grok_backend_display_label() -> None:
+    env = {"ARGUS_SKILL_LIFE_BACKEND": "grok"}
+    config = resolve_role_config("manager", env=env)
+    assert config.backend == "grok"
+    assert config.backend_label == "Grok Build"
+
+
+def test_check_backend_readiness_grok_mocked(tmp_path: Path, monkeypatch) -> None:
+    executable = tmp_path / "grok"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def fake_run_text(command, *, timeout_s, input_text=None):
+        import subprocess
+
+        argv = list(command)
+        class Result:
+            def __init__(self, code: int, out: str, err: str = "") -> None:
+                self.returncode = code
+                self.stdout = out
+                self.stderr = err
+
+        if "--version" in argv:
+            return Result(0, "grok 1.0.0 (deadbeef)\n")
+        if "models" in argv:
+            return Result(
+                0,
+                "You are logged in with grok.com.\n\nDefault model: grok-4.5\n",
+            )
+        return Result(1, "", "unexpected")
+
+    monkeypatch.setattr(
+        "argus_skill.core.backend_readiness._run_text",
+        fake_run_text,
+    )
+    report = check_backend_readiness(
+        "grok",
+        AUTH_MODE_SUBSCRIPTION,
+        probe_auth=True,
+        env={"PATH": str(tmp_path), "HOME": str(tmp_path)},
+    )
+    assert report.ok, report.problems
+    assert report.profile.backend == "grok"
+    assert report.version == "1.0.0"
+    assert report.auth_checked is True


### PR DESCRIPTION
## Summary
- Register `grok` (aliases: `grok-build`) as a first-class Argus agent backend
- Headless turns: `--output-format streaming-messages-json` + `--prompt-file` (avoids ARG_MAX)
- Reuse Claude-compatible Messages NDJSON event consumer
- Auth readiness via read-only `grok models` (no model turns / API spend)
- Unit tests in `tests/test_grok_backend.py`

## Test plan
- [x] `python -m pytest tests/test_grok_backend.py -q` (8 passed)
- [x] `argus --doctor --backend grok` (all checks passed; does not change default backend)
- [ ] Maintainer: `argus --setup --non-interactive --backend grok --accept-house-rules`