### PR TITLE
feat(agent-cli): add Qoder (qodercli) as a native backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ argus --setup --non-interactive \
   --accept-house-rules
 ```
 
-Use `copilot`, `pi`, `codex`, `claude`, `opencode`, or `grok` for `--backend`.
+Use `copilot`, `pi`, `codex`, `claude`, `opencode`, `grok`, or `qoder` for `--backend`.
 
 For Grok Build, install and authenticate the official xAI CLI first:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,7 +105,7 @@ argus --setup --non-interactive \
   --accept-house-rules
 ```
 
-`--backend` 可使用 `copilot`、`pi`、`codex`、`claude`、`opencode` 或 `grok`。
+`--backend` 可使用 `copilot`、`pi`、`codex`、`claude`、`opencode`、`grok` 或 `qoder`。
 
 使用 Grok Build 时，请先安装并登录 xAI 官方 CLI：
 

--- a/argus_skill/adapters/agent_cli_backend/_core.py
+++ b/argus_skill/adapters/agent_cli_backend/_core.py
@@ -52,7 +52,7 @@ class AgentCliBackend:
     """``RunnerBackend`` implementation that shells out to a real CLI.
 
     Construct once with the runner backend choice ("codex" / "claude" /
-    "copilot" / "opencode" / "pi" / "grok") and any cross-call defaults
+    "copilot" / "opencode" / "pi" / "grok" / "qoder") and any cross-call defaults
     (e.g. ``default_extra_args``
     for ``-c "config_profile=..."``), then pass the same instance to
     every ``SkillLoop`` actor (author / engineer / reviewer). Each
@@ -67,11 +67,11 @@ class AgentCliBackend:
 
     Args:
         backend: which CLI to drive ("codex" / "claude" / "copilot" /
-            "opencode" / "pi" / "grok").
+            "opencode" / "pi" / "grok" / "qoder").
             Defaults to the bundled runner's default (codex).
         runner_bin: explicit path to the CLI binary. Default: resolve
             from ``$PATH`` (e.g. ``codex`` / ``claude`` / ``copilot`` /
-            ``opencode`` / ``pi`` / ``grok``).
+            ``opencode`` / ``pi`` / ``grok`` / ``qodercli``).
         default_extra_args: appended to every command (after
             ``options.extra_args``). Useful for global ``-c`` flags.
         before_exec: called before each subprocess spawn — used to reset
@@ -427,7 +427,7 @@ def build_agent_cli_backend_from_env() -> AgentCliBackend:
     Honours:
 
       * ``ARGUS_SKILL_RUNNER_BACKEND`` — "codex" / "claude" / "copilot" /
-        "opencode" / "pi" / "grok"
+        "opencode" / "pi" / "grok" / "qoder"
         (default: codex)
       * ``ARGUS_SKILL_RUNNER_BIN``     — path to the CLI binary
       * ``ARGUS_SKILL_RUNNER_EXTRA_ARGS`` — space-separated default args

--- a/argus_skill/agent_cli/_event_consumers.py
+++ b/argus_skill/agent_cli/_event_consumers.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import json
 
 from .runner_backend import (
-    BACKEND_CLAUDE,
     BACKEND_COPILOT,
     BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
+    CLAUDE_FAMILY,
 )
 
 
@@ -115,7 +115,8 @@ class EventConsumerMixin:
         turn_failed: bool,
         fatal_error: str | None,
     ) -> tuple[str | None, bool, bool, str | None]:
-        if self.backend == BACKEND_CLAUDE:
+        if self.backend in CLAUDE_FAMILY:
+            # qoder emits the same stream-json schema as claude.
             return self._consume_claude_event(
                 event=event,
                 thread_id=thread_id,

--- a/argus_skill/agent_cli/_prompt_delivery.py
+++ b/argus_skill/agent_cli/_prompt_delivery.py
@@ -14,11 +14,11 @@ from ._sandbox_commands import (
 )
 from .copilot_home import apply_copilot_home
 from .runner_backend import (
-    BACKEND_CLAUDE,
     BACKEND_COPILOT,
     BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
+    CLAUDE_FAMILY,
 )
 
 _OPENCODE_CONFIG_CONTENT_ENV = "OPENCODE_CONFIG_CONTENT"
@@ -149,7 +149,7 @@ class PromptDeliveryMixin:
             prepared = list(command)
             prepared.extend(["--prompt-file", str(prompt_path)])
             return prepared, None, prompt_path
-        if self.backend != BACKEND_CLAUDE:
+        if self.backend not in CLAUDE_FAMILY:
             return command, prompt, None
         prepared = list(command)
         if "--bare" in prepared:

--- a/argus_skill/agent_cli/_sandbox_commands.py
+++ b/argus_skill/agent_cli/_sandbox_commands.py
@@ -21,6 +21,8 @@ from .runner_backend import (
     BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
+    BACKEND_QODER,
+    CLAUDE_FAMILY,
     RunnerBackend,
 )
 
@@ -234,7 +236,8 @@ class CommandBuilderMixin:
     def _build_command(
         self, *, resume_thread_id: str | None, options
     ) -> list[str]:
-        if self.backend == BACKEND_CLAUDE:
+        if self.backend in CLAUDE_FAMILY:
+            # qoder is a Claude Code fork; it takes the same headless argv.
             return self._build_claude_command(resume_thread_id=resume_thread_id, options=options)
         if self.backend == BACKEND_COPILOT:
             return self._build_copilot_command(
@@ -276,6 +279,7 @@ class CommandBuilderMixin:
             BACKEND_GROK,
             BACKEND_OPENCODE,
             BACKEND_PI,
+            BACKEND_QODER,
         ):
             return options
         if options.sandbox_mode is not None:
@@ -379,28 +383,38 @@ class CommandBuilderMixin:
     def _build_claude_command(
         self, *, resume_thread_id: str | None, options
     ) -> list[str]:
-        command = [
-            self.agent_bin,
-            "-p",
-            "--verbose",
-            "--output-format",
-            "stream-json",
-        ]
+        command = [self.agent_bin, "-p"]
+        # qodercli is a Claude Code fork that shares claude's headless surface
+        # but differs on three flags: it REJECTS --verbose, spells reasoning
+        # effort as --reasoning-effort (claude uses --effort), and takes
+        # snake_case permission modes (bypass_permissions / accept_edits).
+        is_qoder = self.backend == BACKEND_QODER
+        if not is_qoder:
+            command.append("--verbose")
+        command.extend(["--output-format", "stream-json"])
         if options.model:
             command.extend(["--model", options.model])
         if options.reasoning_effort:
-            effort = (
-                "high"
-                if options.reasoning_effort == "xhigh"
-                else options.reasoning_effort
+            # Both claude (--effort) and qodercli (--reasoning-effort) accept the
+            # full set low/medium/high/xhigh/max, so pass the level through
+            # unchanged. (Previously xhigh was downgraded to high, which capped
+            # claude below its top two gears.)
+            command.extend(
+                ["--reasoning-effort" if is_qoder else "--effort",
+                 options.reasoning_effort]
             )
-            command.extend(["--effort", effort])
         if options.sandbox_mode == "read-only":
             command.extend(["--tools", "Read,Glob,Grep"])
         elif options.dangerous_yolo:
-            command.extend(["--permission-mode", "bypassPermissions"])
+            command.extend([
+                "--permission-mode",
+                "bypass_permissions" if is_qoder else "bypassPermissions",
+            ])
         elif options.full_auto:
-            command.extend(["--permission-mode", "acceptEdits"])
+            command.extend([
+                "--permission-mode",
+                "accept_edits" if is_qoder else "acceptEdits",
+            ])
         # --add-dir
         if options.add_dirs:
             for dir_path in options.add_dirs:

--- a/argus_skill/agent_cli/runner_backend.py
+++ b/argus_skill/agent_cli/runner_backend.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 from typing import Literal
 
-RunnerBackend = Literal["codex", "claude", "copilot", "opencode", "pi", "grok"]
+RunnerBackend = Literal["codex", "claude", "copilot", "opencode", "pi", "grok", "qoder"]
 
 BACKEND_CODEX: RunnerBackend = "codex"
 BACKEND_CLAUDE: RunnerBackend = "claude"
@@ -13,7 +13,16 @@ BACKEND_COPILOT: RunnerBackend = "copilot"
 BACKEND_OPENCODE: RunnerBackend = "opencode"
 BACKEND_PI: RunnerBackend = "pi"
 BACKEND_GROK: RunnerBackend = "grok"
+BACKEND_QODER: RunnerBackend = "qoder"
 DEFAULT_RUNNER_BACKEND: RunnerBackend = BACKEND_CODEX
+
+# Qoder's official CLI (``qodercli``) is a Claude Code fork: it accepts the same
+# headless argv (``-p --output-format stream-json --model … --permission-mode …
+# --resume …``) and emits the same stream-json event schema. So ``qoder`` reuses
+# the ``claude`` command builder, event consumer, sandbox policy, and prompt
+# delivery verbatim. This family set is the single source of truth for "treat it
+# like claude" so those call sites never drift apart.
+CLAUDE_FAMILY: frozenset[str] = frozenset({BACKEND_CLAUDE, BACKEND_QODER})
 
 
 def normalize_runner_backend(raw: str | None) -> RunnerBackend:
@@ -28,6 +37,8 @@ def normalize_runner_backend(raw: str | None) -> RunnerBackend:
         return BACKEND_PI
     if value == BACKEND_GROK:
         return BACKEND_GROK
+    if value == BACKEND_QODER:
+        return BACKEND_QODER
     return BACKEND_CODEX
 
 
@@ -42,6 +53,8 @@ def default_runner_bin(backend: RunnerBackend) -> str:
         return "pi"
     if backend == BACKEND_GROK:
         return "grok"
+    if backend == BACKEND_QODER:
+        return "qodercli"
     return "codex"
 
 

--- a/argus_skill/apps/_life_actions.py
+++ b/argus_skill/apps/_life_actions.py
@@ -18,6 +18,7 @@ _LIFE_BACKENDS = (
     "opencode",
     "pi",
     "grok",
+    "qoder",
     "memory",
 )
 

--- a/argus_skill/apps/_runtime_construction.py
+++ b/argus_skill/apps/_runtime_construction.py
@@ -564,7 +564,7 @@ def _resolve_runner_backend_name(
     if explicit:
         return explicit
     resolved = getattr(args, "backend", None)
-    if resolved in ("codex", "claude", "copilot", "opencode", "pi", "grok"):
+    if resolved in ("codex", "claude", "copilot", "opencode", "pi", "grok", "qoder"):
         return resolved
     return None
 
@@ -608,7 +608,7 @@ def build_life_runner(args: argparse.Namespace, *, seed_thread_id: str | None = 
         if scripted_backend is not None:
             runner.backend = scripted_backend
         return runner
-    if args.backend in ("codex", "claude", "copilot", "opencode", "pi", "grok"):
+    if args.backend in ("codex", "claude", "copilot", "opencode", "pi", "grok", "qoder"):
         # These are agent-CLI backends: _SkillLoopRunner drives the selected
         # CLI via AgentCliBackend (per-role resolution), so the
         # SAME runner serves every backend. Gating this on "codex" alone used to

--- a/argus_skill/apps/cli/_parser.py
+++ b/argus_skill/apps/cli/_parser.py
@@ -283,7 +283,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     capability_grp.add_argument(
         "--backend",
-        choices=("copilot", "codex", "claude", "opencode", "pi", "grok"),
+        choices=("copilot", "codex", "claude", "opencode", "pi", "grok", "qoder"),
         default=None,
         help="backend selected by --setup, --doctor, or this daemon launch",
     )

--- a/argus_skill/core/backend_readiness.py
+++ b/argus_skill/core/backend_readiness.py
@@ -30,7 +30,7 @@ SETUP_EXIT_NOT_READY = 3
 SETUP_EXIT_PERSISTENCE = 4
 
 _SUPPORTED_BACKENDS = frozenset(
-    {"codex", "copilot", "claude", "opencode", "pi", "grok"}
+    {"codex", "copilot", "claude", "opencode", "pi", "grok", "qoder"}
 )
 _VERSION_RE = re.compile(
     r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?"
@@ -39,6 +39,9 @@ _AUTH_COMMANDS: dict[str, tuple[str, ...]] = {
     "codex": ("login", "status"),
     "claude": ("auth", "status"),
     "opencode": ("auth", "list"),
+    # qodercli exits non-zero from --list-models when unauthenticated, so it
+    # doubles as a read-only auth probe.
+    "qoder": ("--list-models",),
 }
 _INSTALL_COMMANDS = {
     "codex": "npm install -g @openai/codex@latest",
@@ -47,6 +50,7 @@ _INSTALL_COMMANDS = {
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "pi": "npm install -g --ignore-scripts @earendil-works/pi-coding-agent",
     "grok": "curl -fsSL https://x.ai/cli/install.sh | bash",
+    "qoder": "npm install -g @qoder-ai/qodercli",
 }
 _LOGIN_COMMANDS = {
     "codex": "codex login",
@@ -55,6 +59,7 @@ _LOGIN_COMMANDS = {
     "opencode": "opencode auth login",
     "pi": "pi, then /login",
     "grok": "grok login",
+    "qoder": "qodercli login",
 }
 
 
@@ -388,6 +393,11 @@ def _probe_cli_auth(
             "no XAI_API_KEY or cached Grok login was found; "
             "Grok Build does not expose a read-only auth-status command"
         )
+    if backend == "qoder":
+        # A PAT is the headless path; otherwise fall through to the generic
+        # `qodercli --list-models` probe below, which reports login state.
+        if str(os.environ.get("QODER_PERSONAL_ACCESS_TOKEN") or "").strip():
+            return True, ""
     suffix = _AUTH_COMMANDS.get(backend)
     if suffix is None:
         return False, f"no read-only authentication probe is defined for {backend}"

--- a/argus_skill/core/knobs.py
+++ b/argus_skill/core/knobs.py
@@ -437,9 +437,10 @@ def normalize_cockpit_knob_value(name: str, value: str) -> str:
             "opencode",
             "pi",
             "grok",
+            "qoder",
         }:
             raise ValueError(
-                f"{name} must be codex, claude, copilot, opencode, pi, or grok"
+                f"{name} must be codex, claude, copilot, opencode, pi, grok, or qoder"
             )
         return backend
     if name in _EFFORT_KNOBS:

--- a/argus_skill/core/metrics.py
+++ b/argus_skill/core/metrics.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
 
 _WEB_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"})
 _PROVIDERS = frozenset(
-    {"codex", "copilot", "claude", "opencode", "pi", "grok", "memory"}
+    {"codex", "copilot", "claude", "opencode", "pi", "grok", "qoder", "memory"}
 )
 _CALL_STATUSES = frozenset({"completed", "error", "denied"})
 _PRICING_STATUSES = frozenset({"priced", "partial", "unpriced", "not_billed", "unknown"})

--- a/argus_skill/core/role_config.py
+++ b/argus_skill/core/role_config.py
@@ -21,6 +21,7 @@ _BACKEND_LABEL = {
     "opencode": "OpenCode",
     "pi": "Pi",
     "grok": "Grok Build",
+    "qoder": "Qoder",
     "memory": "memory",
 }
 

--- a/argus_skill/daemon/_life_worker_identity.py
+++ b/argus_skill/daemon/_life_worker_identity.py
@@ -334,6 +334,7 @@ def _preflight_route_on_codex(route: str) -> bool:
         "opencode",
         "pi",
         "grok",
+        "qoder",
     }:
         return True
     role_bin = (

--- a/argus_skill/life/chat/router.py
+++ b/argus_skill/life/chat/router.py
@@ -12,7 +12,7 @@ Commands:
 * ``/status`` — daemon / active queue / history / cost summary
 * ``/config [key=val ...]`` — view/change session defaults
 * ``/identity`` / ``/identity set <text>`` — view or update the identity card
-* ``/backend [codex|claude|copilot|opencode|pi|grok|memory]`` — show or change backend
+* ``/backend [codex|claude|copilot|opencode|pi|grok|qoder|memory]`` — show or change backend
 * ``/reset`` — drop the current codex session id
 * ``/skills [ls|promote <name>]`` — inspect or promote skills
 * ``/backlog [all]`` — list pending tasks or the full backlog
@@ -103,7 +103,7 @@ def help_text(channel_name: str = "") -> str:
 /config [key=val ...] — 调整会话默认值
 /identity — 查看身份卡
 /identity set <text> — 单条消息更新身份卡
-/backend [codex|claude|copilot|opencode|pi|grok|memory] — 查看或切换后端
+/backend [codex|claude|copilot|opencode|pi|grok|qoder|memory] — 查看或切换后端
 /reset — 清除当前 codex 会话
 /skills [ls|promote <name>] — 查看或提升技能
 /backlog [all] — 查看待办任务

--- a/argus_skill/roles/prompts/manager.py
+++ b/argus_skill/roles/prompts/manager.py
@@ -242,7 +242,7 @@ def build_config_intent_prompt(text: str) -> str:
         "Argus has four roles — manager, planner, engineer, reviewer. The "
         "operator-changeable settings are:\n"
         "  PER-ROLE (may name one role, several, or ALL / the shared default):\n"
-        "    backend  — which agent CLI runs a role: codex | claude | copilot | opencode | pi | grok\n"
+        "    backend  — which agent CLI runs a role: codex | claude | copilot | opencode | pi | grok | qoder\n"
         "    model    — which model a role calls, e.g. gpt-5.5, claude-sonnet-5, "
         "o3, gemini-3.5 (any id the backend supports)\n"
         "    effort   — a role's reasoning effort: low | medium | high | max | xhigh\n"

--- a/argus_skill/tools/setup.py
+++ b/argus_skill/tools/setup.py
@@ -95,6 +95,7 @@ _SUPPORTED_AGENT_BACKENDS = (
     "opencode",
     "pi",
     "grok",
+    "qoder",
 )
 _BACKEND_INSTALL_COMMANDS = {
     "copilot": "npm install -g @github/copilot",
@@ -103,6 +104,7 @@ _BACKEND_INSTALL_COMMANDS = {
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "pi": "npm install -g --ignore-scripts @earendil-works/pi-coding-agent",
     "grok": "curl -fsSL https://x.ai/cli/install.sh | bash",
+    "qoder": "npm install -g @qoder-ai/qodercli",
 }
 
 
@@ -147,11 +149,11 @@ def _configure_runner_backend(requested: str | None = None) -> str | None:
     selected = (
         str(requested).strip().lower()
         if requested is not None
-        else _prompt("Backend (copilot/codex/claude/opencode/pi/grok)", default).lower()
+        else _prompt("Backend (copilot/codex/claude/opencode/pi/grok/qoder)", default).lower()
     )
     if selected not in _SUPPORTED_AGENT_BACKENDS:
         print(_yellow(f"  Unknown backend '{selected}'."))
-        print(_dim("    Choose one of: copilot, codex, claude, opencode, pi, grok"))
+        print(_dim("    Choose one of: copilot, codex, claude, opencode, pi, grok, qoder"))
         print()
         return None
 
@@ -167,6 +169,9 @@ def _configure_runner_backend(requested: str | None = None) -> str | None:
             print(_dim("    Then run `pi` and use `/login` to authenticate."))
         elif selected == "grok":
             print(_dim("    Then authenticate with: grok login"))
+        elif selected == "qoder":
+            print(_dim("    Then authenticate with: qodercli login"))
+            print(_dim("    Or set QODER_PERSONAL_ACCESS_TOKEN for headless use."))
         print()
         return None
 

--- a/argus_skill/verticals/research/academic_language_review.py
+++ b/argus_skill/verticals/research/academic_language_review.py
@@ -1100,7 +1100,7 @@ def describe_reviewer_route_unavailable(
         backend = resolve_role_backend("reviewer", env=env).strip().lower()
     except Exception:  # pragma: no cover - never mask the underlying error
         return base
-    if route_missing and backend in {"copilot", "claude", "pi", "grok"}:
+    if route_missing and backend in {"copilot", "claude", "pi", "grok", "qoder"}:
         return (
             f"{base} — note: the reviewer role runs on the {backend!r} agent-CLI "
             "backend, which authenticates through its own CLI and exposes no "

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -40,6 +40,7 @@ command -v claude || true
 command -v pi || true
 command -v opencode || true
 command -v grok || true
+command -v qodercli || true
 ```
 
 Select the CLI hosting the current conversation when possible. Otherwise,
@@ -54,6 +55,7 @@ values are:
 | Pi | `pi` |
 | OpenCode | `opencode` |
 | xAI Grok Build | `grok` |
+| Qoder CLI | `qoder` |
 
 If prerequisites are missing, explain the proposed installation command and
 obtain approval before using a system package manager, `sudo`, or making a
@@ -103,7 +105,7 @@ From the Argus checkout, run:
 
 ```bash
 .venv/bin/argus --setup --non-interactive \
-  --backend <copilot|codex|claude|pi|opencode|grok> \
+  --backend <copilot|codex|claude|pi|opencode|grok|qoder> \
   --accept-house-rules
 ```
 

--- a/docs/backend-providers.md
+++ b/docs/backend-providers.md
@@ -1,6 +1,6 @@
 # Backend providers
 
-Argus drives six agent CLIs. Two of them — **Pi** and **OpenCode** — are
+Argus drives seven agent CLIs. Two of them — **Pi** and **OpenCode** — are
 provider-agnostic fronts: the CLI holds credentials for one or more provider
 catalogs, and which one serves a request depends on the model id you select.
 This page covers how Argus picks that catalog, and what changed in the
@@ -17,6 +17,7 @@ Argus passes the model id you configured (`ARGUS_SKILL_MODEL`, or a per-role
 | `copilot` | the id verbatim | single catalog |
 | `claude` | the id verbatim | single catalog |
 | `grok` | the id verbatim | xAI Grok Build catalog; login with `grok login` or set `XAI_API_KEY` |
+| `qoder` | the id verbatim | Qoder CLI (`qodercli`, a Claude Code fork); `qodercli login` or set `QODER_PERSONAL_ACCESS_TOKEN` |
 | `pi` | the id verbatim, or `<provider>/<id>` when `ARGUS_SKILL_PI_PROVIDER` is set | Pi resolves a bare id against its authenticated catalogs |
 | `opencode` | `<provider>/<id>`, built from `ARGUS_SKILL_OPENCODE_PROVIDER` | `opencode run --model` rejects a bare id, so without the provider the model setting is dropped |
 
@@ -26,6 +27,7 @@ Run the CLI's own listing to see what you actually hold keys for:
 pi --list-models
 opencode auth list
 grok --version
+qodercli --list-models
 ```
 
 ## Grok Build
@@ -47,6 +49,27 @@ turns with `--resume`.
 Read-only roles receive only `read_file`, `grep`, and `list_dir`. Trusted
 unattended execution maps Argus full-auto mode to Grok's `--yolo`; project or
 organization deny rules still take precedence inside Grok.
+
+## Qoder
+
+Install Qoder's official CLI and authenticate:
+
+```bash
+npm install -g @qoder-ai/qodercli
+qodercli login            # browser OAuth; tokens refresh automatically
+argus --setup --non-interactive --backend qoder --accept-house-rules
+```
+
+For CI or a headless daemon, create a Personal Access Token at
+`https://qoder.com/account/integrations` and set `QODER_PERSONAL_ACCESS_TOKEN`
+instead of the browser login. `qodercli` stores config under `~/.qoder`; point
+`QODER_CONFIG_DIR` at durable storage when `$HOME` is ephemeral.
+
+`qodercli` is a Claude Code fork, so Argus reuses the entire `claude` code path:
+it invokes `qodercli -p --output-format stream-json`, passes the model with
+`--model`, and resumes sessions with `--resume`. List the models your account
+holds with `qodercli --list-models`, then set `ARGUS_SKILL_ENGINEER_MODEL` (and
+the other per-role model knobs) to one of them.
 
 ## Setting a provider
 
@@ -75,6 +98,10 @@ For Grok, readiness checks the CLI version and verifies that either
 model turn. Grok does not currently expose a read-only auth-status command, so
 an expired cached login is reported when the first provider call asks for
 reauthentication.
+
+For Qoder, readiness treats a set `QODER_PERSONAL_ACCESS_TOKEN` as ready;
+otherwise it runs `qodercli --list-models`, which exits non-zero until you log
+in, so an unauthenticated CLI is reported without spending a model turn.
 
 For the Pi backend, readiness reads `pi --list-models` — which lists only
 AUTHENTICATED models — and reports:

--- a/tests/apps/test_cli_parser.py
+++ b/tests/apps/test_cli_parser.py
@@ -107,6 +107,11 @@ def test_parser_accepts_grok_backend() -> None:
     assert args.backend == "grok"
 
 
+def test_parser_accepts_qoder_backend() -> None:
+    args = build_parser().parse_args(["--doctor", "--backend", "qoder"])
+    assert args.backend == "qoder"
+
+
 def test_parser_exposes_cli_doctor() -> None:
     args = build_parser().parse_args(["--doctor", "--backend", "copilot"])
 

--- a/tests/cli/test_roles_status.py
+++ b/tests/cli/test_roles_status.py
@@ -122,6 +122,13 @@ def test_grok_backend_has_display_label():
     assert config.backend_label == "Grok Build"
 
 
+def test_qoder_backend_has_display_label():
+    env = {"ARGUS_SKILL_LIFE_BACKEND": "qoder"}
+    config = resolve_role_config("manager", env=env)
+    assert config.backend == "qoder"
+    assert config.backend_label == "Qoder"
+
+
 def test_memory_backend_preserved():
     env = {"ARGUS_SKILL_LIFE_BACKEND": "memory"}
     assert resolve_role_config("engineer", env=env).backend == "memory"

--- a/tests/core/test_backend_readiness.py
+++ b/tests/core/test_backend_readiness.py
@@ -225,6 +225,47 @@ def test_grok_readiness_reports_login_when_no_credentials_exist(
     assert "grok login" in report.problems[0].remediation
 
 
+def test_qoder_readiness_accepts_pat_without_spending_a_turn(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("QODER_PERSONAL_ACCESS_TOKEN", "pat-token")
+    monkeypatch.setattr(readiness, "resolve_runner_bin", lambda *_args: "/bin/qodercli")
+
+    def run(command, *, timeout_s, input_text=None):
+        del timeout_s, input_text
+        # PAT short-circuits auth, so the only subprocess is the version probe.
+        assert command[-1] == "--version"
+        return _completed("qodercli 1.1.20\n")
+
+    monkeypatch.setattr(readiness, "_run_text", run)
+
+    report = readiness.check_backend_readiness("qoder", "subscription_cli")
+
+    assert report.ok
+    assert report.auth_checked
+    assert report.version == "1.1.20"
+
+
+def test_qoder_readiness_reports_login_when_unauthenticated(monkeypatch) -> None:
+    monkeypatch.delenv("QODER_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(readiness, "resolve_runner_bin", lambda *_args: "/bin/qodercli")
+
+    def run(command, *, timeout_s, input_text=None):
+        del timeout_s, input_text
+        if command[-1] == "--list-models":
+            # qodercli exits non-zero from --list-models when not logged in.
+            return _completed("", returncode=1, stderr="not authenticated")
+        return _completed("qodercli 1.1.20\n")
+
+    monkeypatch.setattr(readiness, "_run_text", run)
+
+    report = readiness.check_backend_readiness("qoder", "subscription_cli")
+
+    assert not report.ok
+    assert report.problems[0].capability == "authentication"
+    assert "qodercli login" in report.problems[0].remediation
+
+
 def test_subscription_mode_never_loads_model_api_vault(monkeypatch) -> None:
     _fake_codex(monkeypatch, "0.144.5")
     monkeypatch.setattr(

--- a/tests/test_config_help.py
+++ b/tests/test_config_help.py
@@ -165,9 +165,10 @@ def test_cockpit_value_normalization_is_typed() -> None:
     assert normalize_cockpit_knob_value("ARGUS_SKILL_ENGINEER_BACKEND", "opencod") == "opencode"
     assert normalize_cockpit_knob_value("ARGUS_SKILL_ENGINEER_BACKEND", "PI") == "pi"
     assert normalize_cockpit_knob_value("ARGUS_SKILL_ENGINEER_BACKEND", "GROK") == "grok"
+    assert normalize_cockpit_knob_value("ARGUS_SKILL_ENGINEER_BACKEND", "QODER") == "qoder"
     with pytest.raises(
         ValueError,
-        match="codex, claude, copilot, opencode, pi, or grok",
+        match="codex, claude, copilot, opencode, pi, grok, or qoder",
     ):
         normalize_cockpit_knob_value("ARGUS_SKILL_ENGINEER_BACKEND", "magic")
     with pytest.raises(ValueError, match="non-negative integer"):

--- a/tests/test_qoder_backend.py
+++ b/tests/test_qoder_backend.py
@@ -1,0 +1,144 @@
+"""Qoder backend reuses the Claude Code code path.
+
+``qodercli`` is a Claude Code fork: same headless argv, same stream-json event
+schema. Argus therefore routes ``qoder`` through ``_build_claude_command`` and
+``_consume_claude_event`` (via ``CLAUDE_FAMILY``). These tests pin that reuse so
+a future divergence in either path is caught.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from argus_skill.agent_cli.agent_cli_runner import AgentCliRunner, RunnerOptions
+from argus_skill.agent_cli.runner_backend import (
+    BACKEND_QODER,
+    CLAUDE_FAMILY,
+    default_runner_bin,
+    normalize_runner_backend,
+)
+
+
+def _runner(agent_bin: str = "qodercli") -> AgentCliRunner:
+    return AgentCliRunner(agent_bin=agent_bin, backend=BACKEND_QODER)
+
+
+def test_qoder_is_registered_and_in_claude_family() -> None:
+    assert normalize_runner_backend("qoder") == BACKEND_QODER
+    assert normalize_runner_backend("QODER") == BACKEND_QODER
+    assert default_runner_bin(BACKEND_QODER) == "qodercli"
+    assert BACKEND_QODER in CLAUDE_FAMILY
+
+
+def test_qoder_command_matches_claude_headless_shape_without_verbose() -> None:
+    # qodercli emits the same stream-json as claude but REJECTS --verbose
+    # (`unknown option '--verbose'`), so qoder's argv drops that one flag.
+    command = _runner()._build_command(
+        resume_thread_id="sess-1",
+        options=RunnerOptions(model="qoder-max", dangerous_yolo=True),
+    )
+
+    assert Path(command[0]).name == "qodercli"
+    assert "--verbose" not in command
+    assert command[1:] == [
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--model",
+        "qoder-max",
+        "--permission-mode",
+        "bypass_permissions",
+        "--resume",
+        "sess-1",
+    ]
+
+
+def test_qoder_flag_dialect_differs_from_claude() -> None:
+    # qodercli's three argv divergences from claude: no --verbose,
+    # --reasoning-effort (not --effort), snake_case permission modes.
+    from argus_skill.agent_cli.runner_backend import BACKEND_CLAUDE
+
+    def build(backend: str, **opts) -> list[str]:
+        return AgentCliRunner(agent_bin="x", backend=backend)._build_command(
+            resume_thread_id=None, options=RunnerOptions(**opts)
+        )
+
+    qoder = build("qoder", model="m", reasoning_effort="high", full_auto=True)
+    assert "--verbose" not in qoder
+    assert "--reasoning-effort" in qoder and "--effort" not in qoder
+    assert "accept_edits" in qoder and "acceptEdits" not in qoder
+
+    claude = build(BACKEND_CLAUDE, model="m", reasoning_effort="high", dangerous_yolo=True)
+    assert "--verbose" in claude
+    assert "--effort" in claude and "--reasoning-effort" not in claude
+    assert "bypassPermissions" in claude
+
+
+def test_qoder_read_only_restricts_tools() -> None:
+    command = _runner()._build_command(
+        resume_thread_id=None,
+        options=RunnerOptions(sandbox_mode="read-only", full_auto=True),
+    )
+
+    assert command.count("--tools") == 1
+    assert command[command.index("--tools") + 1] == "Read,Glob,Grep"
+    # read-only wins over full-auto: no acceptEdits/bypass permission flag.
+    assert "--permission-mode" not in command
+
+
+def test_qoder_stream_tracks_session_text_and_completion() -> None:
+    runner = _runner()
+    messages: list[str] = []
+    state = runner._consume_event(
+        event={
+            "type": "assistant",
+            "session_id": "qsid",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+            },
+        },
+        thread_id=None,
+        agent_messages=messages,
+        turn_completed=False,
+        turn_failed=False,
+        fatal_error=None,
+    )
+    state = runner._consume_event(
+        event={
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "session_id": "qsid",
+            "result": "done",
+        },
+        thread_id=state[0],
+        agent_messages=messages,
+        turn_completed=state[1],
+        turn_failed=state[2],
+        fatal_error=state[3],
+    )
+
+    assert messages == ["done"]
+    assert state == ("qsid", True, False, None)
+
+
+def test_qoder_error_result_fails_closed() -> None:
+    state = _runner()._consume_event(
+        event={
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "session_id": "qsid",
+            "result": "authentication failed",
+        },
+        thread_id=None,
+        agent_messages=[],
+        turn_completed=False,
+        turn_failed=False,
+        fatal_error=None,
+    )
+
+    assert state[0] == "qsid"
+    assert state[1] is False
+    assert state[2] is True
+    assert state[3]

--- a/tests/test_runner_binary_resolution.py
+++ b/tests/test_runner_binary_resolution.py
@@ -9,6 +9,7 @@ from argus_skill.agent_cli.runner_backend import (
     BACKEND_GROK,
     BACKEND_OPENCODE,
     BACKEND_PI,
+    BACKEND_QODER,
     resolve_available_runner,
     resolve_runner_bin,
 )
@@ -57,6 +58,16 @@ def test_grok_runner_uses_grok_binary(tmp_path: Path, monkeypatch) -> None:
 
     assert resolve_runner_bin(BACKEND_GROK) == str(executable)
     assert AgentCliRunner(backend=BACKEND_GROK).agent_bin == str(executable)
+
+
+def test_qoder_runner_uses_qodercli_binary(tmp_path: Path, monkeypatch) -> None:
+    executable = tmp_path / "qodercli"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert resolve_runner_bin(BACKEND_QODER) == str(executable)
+    assert AgentCliRunner(backend=BACKEND_QODER).agent_bin == str(executable)
 
 
 def test_opencode_runner_resolves_standard_install_directory(


### PR DESCRIPTION
qodercli is a Claude Code-like harness, so `qoder` joins the runner registry as a member of a new CLAUDE_FAMILY set and reuses claude's command builder, stream-json event consumer, sandbox policy, and prompt delivery. It diverges from claude only where qodercli's flags differ: no --verbose (rejected), --reasoning-effort instead of --effort, and snake_case permission modes (bypass_permissions / accept_edits).

Registered across every backend membership gate (--backend choices, runtime construction, life backends, knobs, metrics, role labels, readiness, setup, worker identity) so --backend qoder / --doctor / --setup / /backend / per-role ARGUS_SKILL_<ROLE>_BACKEND all recognize it. Auth via QODER_PERSONAL_ACCESS_TOKEN, else a read-only `qodercli --list-models` probe.

Also stop downgrading reasoning effort xhigh->high: both claude and qodercli accept the full low/medium/high/xhigh/max set, so the level is passed through unchanged (claude was previously capped at high).

Tests: new tests/test_qoder_backend.py plus backend-set assertion updates in the cli parser, runner-binary, roles-status, backend-readiness and config-help tests.