### PR TITLE
docs: clarify Windows installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,28 @@ The agent will follow the **[installation execution contract](docs/agent-install
 ```bash
 git clone https://github.com/lbx154/Argus.git
 cd Argus
+```
 
+Linux and macOS:
+
+```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
-pip install -e .
+python -m pip install -e .
 ```
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -e .
+```
+
+The Windows commands call the virtual environment directly, so activation is
+not required. Before using the shorter `argus` commands below, either run
+`.\.venv\Scripts\Activate.ps1` or invoke `.\.venv\Scripts\argus.exe` directly.
 
 ### Connect a backend
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,12 +85,28 @@ Agent 将遵循 **[安装执行规范](docs/agent-install.md)**。
 ```bash
 git clone https://github.com/lbx154/Argus.git
 cd Argus
+```
 
+Linux 和 macOS：
+
+```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
-pip install -e .
+python -m pip install -e .
 ```
+
+Windows PowerShell：
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -e .
+```
+
+Windows 命令直接调用虚拟环境中的 Python，因此无需激活。执行下文较短的 `argus`
+命令前，可运行 `.\.venv\Scripts\Activate.ps1`，或直接调用
+`.\.venv\Scripts\argus.exe`。
 
 源码安装后可用一条命令更新：
 


### PR DESCRIPTION
## Summary

- separate the source-install steps for Linux/macOS and Windows PowerShell
- use the virtual environment's Python executable directly on Windows
- explain how subsequent `argus` commands work with or without activation

## Why

The existing install block uses the POSIX-only `. .venv/bin/activate` command. PowerShell users receive a command-not-found error even after creating the virtual environment successfully.

## Impact

Windows users can follow a copyable installation sequence without changing their execution policy. The existing Linux/macOS flow remains unchanged.

## Validation

- `git diff --check`
- verified the remote commit tree matches the local commit tree
- verified the branch is one commit ahead and changes only `README.md` and `README.zh-CN.md`
