### PR TITLE
fix(setup): configure and validate the backend model selector

### DIFF
--- a/argus_skill/core/backend_readiness.py
+++ b/argus_skill/core/backend_readiness.py
@@ -253,12 +253,187 @@ def _probe_pi_catalog(
 
 
 #: Roles whose configured model Argus will hand to the backend verbatim.
-_PI_MODEL_ROLES: tuple[tuple[str, str], ...] = (
+_MODEL_ROLES: tuple[tuple[str, str], ...] = (
     ("manager", "ARGUS_SKILL_MANAGER_MODEL"),
     ("planner", "ARGUS_SKILL_PLAN_MODEL"),
     ("engineer", "ARGUS_SKILL_ENGINEER_MODEL"),
     ("reviewer", "ARGUS_SKILL_REVIEWER_MODEL"),
 )
+
+#: Model-id prefixes that identify the vendor catalog an id was minted for.
+#: Deliberately incomplete: an id matching nothing here is simply unknown, and
+#: an unknown id never raises a complaint (a private gateway may serve any
+#: name it likes). Only a POSITIVE match on the WRONG catalog is actionable.
+_MODEL_CATALOG_PREFIXES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("openai", ("gpt-", "gpt5", "o1-", "o3-", "o4-", "codex-")),
+    ("anthropic", ("claude-",)),
+    ("xai", ("grok-",)),
+    ("deepseek", ("deepseek-",)),
+)
+
+#: Backends whose CLI serves exactly ONE vendor catalog, so a model id from a
+#: different catalog cannot resolve. Deliberately excluded:
+#: ``copilot`` (GitHub resells several vendors, Anthropic ids included),
+#: ``qoder`` (its own catalog; read it with ``qodercli --list-models``),
+#: ``pi`` / ``opencode`` (provider-agnostic fronts — ``_check_pi_model_routing``
+#: judges Pi against its real authenticated catalog instead), and ``dsh``
+#: (Argus sends ``provider/model`` through the ``ARGUS_DSH_*`` overlay, so the
+#: bare id here is not the whole selector and judging it would misfire).
+_BACKEND_MODEL_CATALOG: dict[str, str] = {
+    "codex": "openai",
+    "claude": "anthropic",
+    "grok": "xai",
+}
+
+#: Model Argus adopts for a backend when the operator never chose one.
+#: Populated only where the id is verified against a real CLI; a backend absent
+#: from this table keeps the shared default and relies on
+#: :func:`_check_backend_model_catalog` to say so out loud.
+_BACKEND_DEFAULT_MODELS: dict[str, str] = {
+    "claude": "claude-opus-5",
+}
+
+
+def _model_catalog(model: str) -> str:
+    """Vendor catalog a model id belongs to, or ``""`` when unrecognized."""
+    lowered = str(model or "").strip().lower()
+    for catalog, prefixes in _MODEL_CATALOG_PREFIXES:
+        if lowered.startswith(prefixes):
+            return catalog
+    return ""
+
+
+def _explicit_model_selection(
+    role_env: str,
+    *,
+    env: Mapping[str, str],
+    persisted: Mapping[str, str],
+) -> str:
+    """The model id the OPERATOR chose for a role, or ``""`` when they never did.
+
+    Resolving with an empty default makes the distinction structural: only the
+    ``env`` and ``persisted`` layers can return a non-empty value, so anything
+    non-empty here was deliberately configured by a human.
+    """
+    from .knobs import resolve_knob
+
+    for name in (role_env, "ARGUS_SKILL_MODEL"):
+        if not name:
+            continue
+        chosen = resolve_knob(name, "", env=env, persisted=persisted).value.strip()
+        if chosen:
+            return chosen
+    return ""
+
+
+def default_model_for_backend(
+    backend: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    persisted: Mapping[str, str] | None = None,
+) -> str:
+    """Model id setup should adopt for ``backend``, or ``""`` to leave it alone.
+
+    Returns a value only when BOTH hold: the backend has a verified default,
+    and the operator has not chosen a model themselves. An explicit choice is
+    never second-guessed, so re-running setup cannot silently retune a machine
+    that was already configured by hand.
+    """
+    normalized = normalize_runner_backend(backend)
+    adopted = _BACKEND_DEFAULT_MODELS.get(normalized, "")
+    if not adopted:
+        return ""
+    env_map = env if env is not None else os.environ
+    persisted_map = persisted if persisted is not None else read_persisted_knobs()
+    for _route, role_env in _MODEL_ROLES:
+        if _explicit_model_selection(role_env, env=env_map, persisted=persisted_map):
+            return ""
+    return adopted
+
+
+def _check_backend_model_catalog(
+    report: BackendReadiness,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Verify the model ids Argus will send belong to the backend's own catalog.
+
+    The gap this closes: readiness validated that the CLI existed, ran, and was
+    authenticated — never that the model selector was one that CLI could serve.
+    Argus's shared default (``gpt-5.5``) is an OpenAI-catalog id, so
+    ``argus --setup --backend claude`` produced a machine that passed every
+    check and then failed EVERY call with "There's an issue with the selected
+    model (gpt-5.5)". Worse, the Manager front door reports any non-zero
+    backend exit as "Manager could not classify this message", so the operator
+    never saw the model name at all.
+
+    Severity splits on WHO chose the id, matching the Pi precedent above. An
+    id nobody chose is a hard problem: it is Argus's own default landing on a
+    catalog that cannot serve it, and the failure is deterministic. An id the
+    operator set by hand is a warning: they may be pointing the CLI at a
+    private gateway that really does serve it, and a false red doctor is worse
+    than an unheeded warning.
+
+    中文：原先只校验 CLI 是否存在/已登录，从不校验下发的 model id 是否属于该
+    后端的目录。默认值 ``gpt-5.5`` 是 OpenAI 目录的 id，于是
+    ``--setup --backend claude`` 全绿通过、每次调用必失败。这里按「谁选的」
+    分级：默认值选错 = 硬失败；操作者显式设置 = 仅告警（可能接了私有网关）。
+    """
+    from .knobs import resolve_role_model
+
+    expected = _BACKEND_MODEL_CATALOG.get(report.profile.backend)
+    if expected is None:
+        return
+    env_map = env if env is not None else os.environ
+    persisted_map = read_persisted_knobs()
+    # Roles usually share one model id; speak once per distinct selector.
+    seen: set[str] = set()
+    for route, role_env in _MODEL_ROLES:
+        model = str(
+            resolve_role_model(route, role_env=role_env, env=env_map) or ""
+        ).strip()
+        if not model or model in seen:
+            continue
+        seen.add(model)
+        actual = _model_catalog(model)
+        if not actual or actual == expected:
+            continue
+        chosen = _explicit_model_selection(
+            role_env, env=env_map, persisted=persisted_map
+        )
+        if chosen:
+            report.warnings.append(
+                f"the {route} model {model!r} looks like an {actual} id but "
+                f"the {report.profile.backend} CLI serves the {expected} "
+                f"catalog; keep it only if that CLI is pointed at a gateway "
+                f"that carries it"
+            )
+            continue
+        adopted = _BACKEND_DEFAULT_MODELS.get(report.profile.backend, "")
+        fix = (
+            f"re-run `argus --setup --backend {report.profile.backend}` to "
+            f"adopt {adopted}, or set ARGUS_SKILL_MODEL to a model that CLI "
+            f"serves"
+            if adopted
+            else (
+                f"set ARGUS_SKILL_MODEL (or {role_env}) to a model the "
+                f"{report.profile.backend} CLI serves, then re-run "
+                f"`argus --doctor`"
+            )
+        )
+        report.problems.append(
+            ReadinessProblem(
+                "model selector",
+                (
+                    f"the {route} model resolves to {model!r}, an {actual} "
+                    f"catalog id, but {report.profile.backend} serves the "
+                    f"{expected} catalog; no model is configured, so this is "
+                    f"Argus's shared default and every call will fail"
+                ),
+                fix,
+            )
+        )
+        return
 
 
 def _check_pi_model_routing(
@@ -315,7 +490,7 @@ def _check_pi_model_routing(
     # Roles usually share one model id; warn once per distinct selector rather
     # than four times over.
     seen: set[str] = set()
-    for route, role_env in _PI_MODEL_ROLES:
+    for route, role_env in _MODEL_ROLES:
         model = str(
             resolve_role_model(route, role_env=role_env, env=env_map) or ""
         ).strip()
@@ -674,19 +849,39 @@ def check_backend_readiness(
             )
         elif pi_catalog:
             _check_pi_model_routing(report, pi_catalog, env=env_map)
+    if profile.auth_mode == AUTH_MODE_SUBSCRIPTION:
+        # Subscription mode only: under model_api the operator points Codex at
+        # an arbitrary OpenAI-compatible endpoint, so a foreign-looking id may
+        # be exactly right and the vault check above already judges the route.
+        _check_backend_model_catalog(report, env=env_map)
     return report
 
 
-def persist_validated_profile(report: BackendReadiness) -> bool:
+def persist_validated_profile(
+    report: BackendReadiness,
+    *,
+    model: str = "",
+) -> bool:
+    """Persist the validated backend profile, and the model chosen with it.
+
+    ``model`` carries the id setup adopted from
+    :func:`default_model_for_backend` (empty when the operator had already
+    chosen one, or when the backend has no verified default). Writing it here
+    is what stops a Codex-shaped shared default from silently becoming the
+    selector for a non-OpenAI backend — the Pi path has always persisted its
+    model this way; every other backend used to persist none.
+    """
     if not report.ok:
         return False
-    return write_persisted_knobs(
-        {
-            "ARGUS_SKILL_RUNNER_BACKEND": report.profile.backend,
-            AUTH_MODE_KNOB: report.profile.auth_mode,
-            "ARGUS_SKILL_BACKEND_VALIDATED_VERSION": report.version,
-        }
-    )
+    values = {
+        "ARGUS_SKILL_RUNNER_BACKEND": report.profile.backend,
+        AUTH_MODE_KNOB: report.profile.auth_mode,
+        "ARGUS_SKILL_BACKEND_VALIDATED_VERSION": report.version,
+    }
+    adopted = str(model or "").strip()
+    if adopted:
+        values["ARGUS_SKILL_MODEL"] = adopted
+    return write_persisted_knobs(values)
 
 
 def format_backend_readiness(report: BackendReadiness) -> str:

--- a/argus_skill/tools/setup.py
+++ b/argus_skill/tools/setup.py
@@ -21,6 +21,7 @@ from ..core.backend_readiness import (
     SETUP_EXIT_PERSISTENCE,
     SETUP_EXIT_USAGE,
     check_backend_readiness,
+    default_model_for_backend,
     format_backend_readiness,
     persist_validated_profile,
 )
@@ -356,6 +357,12 @@ def _run_noninteractive_setup(
         assert pi_config is not None
         os.environ["ARGUS_SKILL_PI_PROVIDER"] = "argus"
         os.environ["ARGUS_SKILL_MODEL"] = pi_config[0]
+    # Adopt the backend's own model BEFORE readiness runs, so the check below
+    # judges the selector this machine will really send. Mirrors how the Pi
+    # branch above seeds ARGUS_SKILL_MODEL ahead of the same call.
+    adopted_model = default_model_for_backend(selected)
+    if adopted_model:
+        os.environ["ARGUS_SKILL_MODEL"] = adopted_model
     _ensure_default_house_rules_prompt()
     report = check_backend_readiness(
         selected,
@@ -369,7 +376,7 @@ def _run_noninteractive_setup(
     stream.write(rendered + "\n")
     if not report.ok:
         return SETUP_EXIT_NOT_READY
-    if not persist_validated_profile(report):
+    if not persist_validated_profile(report, model=adopted_model):
         sys.stderr.write("argus: readiness passed but profile persistence failed\n")
         return SETUP_EXIT_PERSISTENCE
     if pi_config is not None and not _persist_pi_profile(pi_config[0]):
@@ -1296,6 +1303,12 @@ def run_setup(
             print(_dim("  Using Pi's existing login/configuration."))
         print()
 
+    adopted_model = default_model_for_backend(selected_backend)
+    if adopted_model:
+        os.environ["ARGUS_SKILL_MODEL"] = adopted_model
+        print(f"  {_green('✓')} Model selected → {adopted_model}")
+        print()
+
     house_rules_path = _ensure_default_house_rules_prompt()
     if house_rules_path is not None:
         print(f"  {_green('✓')} House rules created")
@@ -1312,7 +1325,7 @@ def run_setup(
     if not report.ok:
         print(_yellow("  Setup is not ready; the backend profile was not persisted."))
         return SETUP_EXIT_NOT_READY
-    if not persist_validated_profile(report):
+    if not persist_validated_profile(report, model=adopted_model):
         print(_yellow("  Readiness passed but backend profile persistence failed."))
         return SETUP_EXIT_PERSISTENCE
     if pi_config is not None and not _persist_pi_profile(pi_config[0]):

--- a/argus_skill/webapi/diagnostics.py
+++ b/argus_skill/webapi/diagnostics.py
@@ -276,15 +276,17 @@ def _check_backend_preflight(
         auth = "credentials listed; live token not checked"
     else:
         auth = "authentication checked" if report.auth_checked else "configuration checked"
-    return Check(
-        "backend preflight",
-        True,
-        (
-            f"{selected} {report.version} runnable at {report.executable} "
-            f"({report.profile.auth_mode}; {auth}; source={source})"
-        ),
-        "",
+    detail = (
+        f"{selected} {report.version} runnable at {report.executable} "
+        f"({report.profile.auth_mode}; {auth}; source={source})"
     )
+    # A passing report can still carry advisories (an ambiguous Pi model, a
+    # model id that looks foreign to the backend's catalog). The doctor used to
+    # drop them on the floor, which is how a merely-suspicious configuration
+    # stayed invisible until the first real call failed.
+    for warning in report.warnings:
+        detail += f"; warning: {warning}"
+    return Check("backend preflight", True, detail, "")
 
 
 def _continuous_objective(project_root: Path) -> str:

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -139,9 +139,9 @@ then either fix it or ask the user to choose another installed backend.
 
 Argus sends a model id to the backend CLI, and its shared default belongs to
 the OpenAI catalog. Setup adopts a backend-appropriate model where Argus knows
-one, but for any backend it does not, an unset model resolves to an id that CLI
-cannot serve — every call then fails, and the Manager reports it only as
-`[not dispatched] Manager could not classify this message`.
+one. For a single-catalog backend whose catalog conflicts with that default,
+leaving the model unset makes every call fail, and the Manager reports it only
+as `[not dispatched] Manager could not classify this message`.
 
 `argus --setup` reports a `model selector` failure when it can prove the id is
 wrong, so a clean setup already covers most cases. Confirm what each role will

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -135,7 +135,50 @@ Use the backend selected in steps 1-2. Do not silently switch to another
 provider after a failed readiness check. Diagnose the reported failure first,
 then either fix it or ask the user to choose another installed backend.
 
-### 5. Verify the installation
+### 5. Confirm the model selector
+
+Argus sends a model id to the backend CLI, and its shared default belongs to
+the OpenAI catalog. Setup adopts a backend-appropriate model where Argus knows
+one, but for any backend it does not, an unset model resolves to an id that CLI
+cannot serve — every call then fails, and the Manager reports it only as
+`[not dispatched] Manager could not classify this message`.
+
+`argus --setup` reports a `model selector` failure when it can prove the id is
+wrong, so a clean setup already covers most cases. Confirm what each role will
+actually send:
+
+```bash
+.venv/bin/argus --config-help
+```
+
+The `[models]` section prints every model knob with its resolved value and
+where that value came from (`env`, `persisted`, or `default`). A value marked
+`(default)` was chosen by nobody — check that it belongs to the selected
+backend's catalog.
+
+If it does not, list the ids the account really holds. The listing command is
+backend-specific:
+
+```bash
+pi --list-models
+opencode auth list
+qodercli --list-models
+```
+
+Set the chosen id in the environment Argus launches from:
+
+```bash
+export ARGUS_SKILL_MODEL=<model-id>
+```
+
+`ARGUS_SKILL_MODEL` is the shared default; per-role knobs
+(`ARGUS_SKILL_MANAGER_MODEL`, `ARGUS_SKILL_ENGINEER_MODEL`,
+`ARGUS_SKILL_REVIEWER_MODEL`, `ARGUS_SKILL_PLAN_MODEL`) override it. Ask before
+writing the export into a shell startup file. Inside the running cockpit the
+operator can also say "switch the model to <model-id>", which persists the
+choice for future sessions.
+
+### 6. Verify the installation
 
 Run:
 
@@ -152,12 +195,13 @@ If the user wants `argus` available outside the checkout, offer a safe PATH or
 launcher option appropriate for their operating system. Do not edit shell
 startup files without approval.
 
-### 6. Report the result
+### 7. Report the result
 
 Tell the user:
 
 - the Argus installation directory;
 - the selected backend;
+- the model id each role will use;
 - whether `argus --doctor` passed;
 - the exact command to start Argus;
 - any remaining manual action.

--- a/tests/core/test_backend_readiness.py
+++ b/tests/core/test_backend_readiness.py
@@ -190,6 +190,10 @@ def test_grok_readiness_accepts_api_key_without_spending_a_turn(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("XAI_API_KEY", "test-key")
+    # An xAI-catalog id, as a real Grok install carries: with no model set at
+    # all the shared OpenAI default resolves instead, which readiness now
+    # rejects on purpose (see test_claude_readiness_fails_on_the_openai_...).
+    monkeypatch.setenv("ARGUS_SKILL_MODEL", "grok-4")
     monkeypatch.setattr(readiness, "resolve_runner_bin", lambda *_args: "/bin/grok")
 
     def run(command, *, timeout_s, input_text=None):
@@ -346,6 +350,143 @@ def test_profile_persistence_only_accepts_ready_report(monkeypatch) -> None:
             "ARGUS_SKILL_BACKEND_VALIDATED_VERSION": "1.0.74",
         }
     ]
+
+
+def test_profile_persistence_records_the_adopted_model(monkeypatch) -> None:
+    """The gap this closes: only the Pi path ever persisted a model, so
+    `--setup --backend claude` left model resolution on the shared OpenAI
+    default and every later call died on an id the CLI cannot serve."""
+    saved: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        readiness,
+        "write_persisted_knobs",
+        lambda values: saved.append(dict(values)) or True,
+    )
+    ready = readiness.BackendReadiness(
+        profile=readiness.BackendProfile(
+            backend="claude",
+            auth_mode="subscription_cli",
+            backend_source="argument",
+            auth_mode_source="argument",
+        ),
+        executable="/bin/claude",
+        version="2.1.232",
+    )
+
+    assert readiness.persist_validated_profile(ready, model="claude-opus-5") is True
+
+    assert saved[0]["ARGUS_SKILL_MODEL"] == "claude-opus-5"
+
+
+def test_backend_default_model_is_adopted_only_when_nobody_chose_one() -> None:
+    assert (
+        readiness.default_model_for_backend("claude", env={}, persisted={})
+        == "claude-opus-5"
+    )
+    # An operator choice on either layer is never second-guessed.
+    assert (
+        readiness.default_model_for_backend(
+            "claude", env={"ARGUS_SKILL_MODEL": "claude-sonnet-5"}, persisted={}
+        )
+        == ""
+    )
+    assert (
+        readiness.default_model_for_backend(
+            "claude", env={}, persisted={"ARGUS_SKILL_ENGINEER_MODEL": "my-model"}
+        )
+        == ""
+    )
+    # A backend with no verified default keeps whatever is configured; the
+    # catalog check below is what makes a wrong id visible there.
+    assert readiness.default_model_for_backend("copilot", env={}, persisted={}) == ""
+
+
+def _fake_claude(monkeypatch, *, version: str = "2.1.232") -> None:
+    monkeypatch.setattr(readiness, "resolve_runner_bin", lambda *_args: "/bin/claude")
+
+    def run(command, *, timeout_s, input_text=None):
+        del timeout_s, input_text
+        if command[-1] == "--version":
+            return _completed(f"{version} (Claude Code)\n")
+        return _completed("Logged in\n")
+
+    monkeypatch.setattr(readiness, "_run_text", run)
+
+
+def test_claude_readiness_fails_on_the_openai_shared_default(
+    monkeypatch, tmp_path
+) -> None:
+    """The regression this locks down: `argus --setup --backend claude`
+    reported ready with model=gpt-5.5, and every message then came back as
+    "[not dispatched] Manager could not classify this message"."""
+    monkeypatch.setenv("ARGUS_SKILL_HOME", str(tmp_path / "argus-home"))
+    monkeypatch.delenv("ARGUS_SKILL_MODEL", raising=False)
+    _fake_claude(monkeypatch)
+
+    report = readiness.check_backend_readiness("claude", "subscription_cli")
+
+    assert not report.ok
+    problem = next(p for p in report.problems if p.capability == "model selector")
+    assert "gpt-5.5" in problem.detail
+    assert "anthropic" in problem.detail
+    assert "claude-opus-5" in problem.remediation
+
+
+def test_claude_readiness_accepts_an_anthropic_model(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ARGUS_SKILL_HOME", str(tmp_path / "argus-home"))
+    monkeypatch.setenv("ARGUS_SKILL_MODEL", "claude-opus-5")
+    _fake_claude(monkeypatch)
+
+    report = readiness.check_backend_readiness("claude", "subscription_cli")
+
+    assert report.ok, [p.detail for p in report.problems]
+    assert not report.warnings
+
+
+def test_an_operator_chosen_foreign_model_only_warns(monkeypatch, tmp_path) -> None:
+    """A hand-set id may be served by a private gateway the CLI points at, so
+    it must not turn the doctor red — but it still gets said out loud."""
+    monkeypatch.setenv("ARGUS_SKILL_HOME", str(tmp_path / "argus-home"))
+    monkeypatch.setenv("ARGUS_SKILL_MODEL", "gpt-5.5")
+    _fake_claude(monkeypatch)
+
+    report = readiness.check_backend_readiness("claude", "subscription_cli")
+
+    assert report.ok, [p.detail for p in report.problems]
+    assert any("gpt-5.5" in warning for warning in report.warnings), report.warnings
+
+
+def test_unknown_model_ids_are_never_second_guessed(monkeypatch, tmp_path) -> None:
+    """Only a POSITIVE match on a foreign catalog is actionable; a private id
+    Argus has never heard of must stay silent."""
+    monkeypatch.setenv("ARGUS_SKILL_HOME", str(tmp_path / "argus-home"))
+    monkeypatch.setenv("ARGUS_SKILL_MODEL", "internal-gateway-v3")
+    _fake_claude(monkeypatch)
+
+    report = readiness.check_backend_readiness("claude", "subscription_cli")
+
+    assert report.ok
+    assert not report.warnings
+
+
+def test_multi_catalog_backends_are_exempt(monkeypatch, tmp_path) -> None:
+    """Copilot resells several vendors (Anthropic ids included), so its
+    selector cannot be judged from the id alone."""
+    monkeypatch.setenv("ARGUS_SKILL_HOME", str(tmp_path / "argus-home"))
+    monkeypatch.setenv("ARGUS_SKILL_MODEL", "claude-opus-5")
+    monkeypatch.setattr(readiness, "resolve_runner_bin", lambda *_args: "/bin/copilot")
+    monkeypatch.setattr(
+        readiness,
+        "_run_text",
+        lambda command, *, timeout_s, input_text=None: _completed(
+            "GitHub Copilot CLI 1.0.78\n"
+        ),
+    )
+
+    report = readiness.check_backend_readiness("copilot", "subscription_cli", probe_auth=False)
+
+    assert report.ok
+    assert not report.warnings
 
 
 def _fake_pi(monkeypatch, catalog: str, *, version: str = "0.83.0") -> None:

--- a/tests/tools/test_setup_readiness.py
+++ b/tests/tools/test_setup_readiness.py
@@ -79,7 +79,7 @@ def test_noninteractive_setup_validates_then_persists_without_global_mutation(
     monkeypatch.setattr(
         setup,
         "persist_validated_profile",
-        lambda _report: calls.append("persist") or True,
+        lambda _report, **_kwargs: calls.append("persist") or True,
     )
     monkeypatch.setattr(
         "argus_skill.agent_cli.runner_backend.resolve_runner_bin",
@@ -154,7 +154,9 @@ def test_noninteractive_api_url_configures_pi_without_backend_flag(
     monkeypatch.setattr(setup, "_pi_models_path", lambda: models_path)
     monkeypatch.setattr(setup, "_configure_runner_backend", lambda backend: backend)
     monkeypatch.setattr(setup, "check_backend_readiness", lambda *_a, **_k: report)
-    monkeypatch.setattr(setup, "persist_validated_profile", lambda _report: True)
+    monkeypatch.setattr(
+        setup, "persist_validated_profile", lambda _report, **_kwargs: True
+    )
     monkeypatch.setattr(
         setup,
         "_persist_pi_profile",


### PR DESCRIPTION
## The bug

`argus --setup --non-interactive --backend claude` completes, `argus --doctor` prints **`all blocking checks passed`**, and then every single message comes back as:

```
[not dispatched] Manager could not classify this message. No task was queued; please retry.
```

The model name never reaches the operator. It is only visible in `~/.argus-skill/cost-control.jsonl`:

```json
{"provider":"claude","model":"gpt-5.5","run_label":"manager-frontdoor-classify",
 "error":"There's an issue with the selected model (gpt-5.5). It may not exist or you may not have access to it."}
```

## Why it happens

Three independent gaps line up:

1. **Setup never persists a model for agent-CLI backends.** `persist_validated_profile` writes `ARGUS_SKILL_RUNNER_BACKEND`, `ARGUS_SKILL_BACKEND_AUTH_MODE`, `ARGUS_SKILL_BACKEND_VALIDATED_VERSION` — and nothing else. Only the Pi path (`_persist_pi_profile`) ever wrote a model. Resolution therefore falls through to the shared default `gpt-5.5` (`core/knobs.py`, `capability_vault._DEFAULT_TEXT_MODEL`), an OpenAI-catalog id. Per `docs/backend-providers.md`, Argus sends it to `claude` **verbatim**.

2. **Readiness never validates the selector.** It checks binary, version and auth. The only model validation was `_check_pi_model_routing`, gated on `profile.backend == "pi"`. Reproduced on a working install:

   ```
   $ ARGUS_SKILL_MODEL=gpt-5.5 argus --doctor
   ✓ ARGUS-BACKEND-001 [backend/ready] claude 2.1.232 ... (subscription_cli; configuration checked; ...)
   all blocking checks passed          # exit 0, on a machine where every call fails
   ```

3. **`docs/agent-install.md` has no step that configures a model.** An agent following it end to end hits every checkpoint the doc defines and reports success truthfully.

The generic error text comes from `life/router.py`, which collapses any non-zero backend exit into `failure_sink("classifier backend failed")`; `webapi/manager_dispatch.py` then fails closed.

## The change

- **`persist_validated_profile(report, *, model="")`** — persists the model adopted for the backend. New `default_model_for_backend()` returns an id only when the backend has a *verified* default **and** the operator chose nothing, so re-running setup never retunes a hand-configured machine.
- **Both setup paths** seed the adopted model into the environment *before* readiness runs — mirroring how the existing Pi branch already seeds `ARGUS_SKILL_MODEL` — then persist it.
- **`_check_backend_model_catalog()`** rejects a model id that *positively* matches a foreign vendor catalog. Severity splits on who chose it, matching the Pi precedent: an id nobody chose is a hard problem (Argus's own default, deterministic failure); an id the operator set by hand is a warning (a private gateway may really serve it). An id matching no known catalog is never second-guessed.
- **The doctor prints readiness warnings** instead of discarding them, so an advisory is visible before the first call rather than after.
- **`docs/agent-install.md`** gains a "Confirm the model selector" step using `argus --config-help` (verified to exist and to print each knob's resolved value and source).

Exempt by design: `copilot` and `qoder` (their CLIs front several catalogs — Copilot resells Anthropic ids), `pi`/`opencode` (provider-agnostic; Pi keeps its real catalog probe), and `dsh` (its selector goes through the `ARGUS_DSH_*` overlay, so judging the bare id would misfire).

Only `claude → claude-opus-5` is seeded, because that is the one id verified against a real CLI here. Other backends keep current behaviour and now get an actionable failure instead of a silent one; adding a default later is a one-line table entry.

## Tests

`tests/core/test_backend_readiness.py` — the `gpt-5.5`-on-claude regression, an accepted Anthropic id, operator-chosen foreign id warns instead of failing, unknown ids stay silent, multi-catalog backends exempt, and the adopted-model persistence.

Two pre-existing test doubles stubbed `persist_validated_profile` positionally and were widened to accept the new keyword. `test_grok_readiness_accepts_api_key_without_spending_a_turn` configured no model at all, so under a hermetic home it resolved to the OpenAI default — exactly what this change now rejects; it sets a `grok-` id, which is what a real Grok install carries.

```
tests/core/test_backend_readiness.py tests/tools/test_setup_readiness.py tests/test_doctor.py   → all pass
python -m ruff check argus_skill tests                                                          → All checks passed
```

`ruff` also caught that the new interactive-setup line used a backslash escape inside an f-string, which is a syntax error on the project's 3.11 floor; it now uses literal glyphs like the surrounding code.

## Note for the maintainer

`tests/core/test_release.py::test_release_manifest_matches_current_shipped_source` fails, because `compute_source_digest` covers `argus_skill/**/*.py` and `generate_manifest` refuses to update without `build_release` rebuilding the shipped frontends. I did not commit a frontend rebuild to keep this diff reviewable — please regenerate the manifest as part of the release flow.

Pre-existing failures unrelated to this change, confirmed by running them on a clean `main`: `tests/tools/test_ppt_master.py` (5) and `tests/webapi/test_pairing.py` (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
