### PR TITLE
docs: surface the WeChat community QR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,26 @@ Manager/Planner/Engineer/Reviewer runtime as a custom agent. See
 **Coding-agent plugin:** use the packaged MCP bridge and host-specific Skills
 without changing the core runtime. See **[Plugin quick start](docs/plugin.md)**.
 
+## WeChat community
+
+Scan the QR code to join the Argus community. Click the image to open it at full
+size. If the printed expiry date has passed, open an Issue and ask the
+maintainers for the latest code.
+
+<p align="center">
+  <a href="docs/assets/argus-wechat-group.jpg">
+    <img src="docs/assets/argus-wechat-group.jpg" width="360" alt="Argus WeChat community QR code">
+  </a>
+</p>
+
 ## Quick Install
 
 Choose the section for your operating system. Do not mix commands between
 platforms. All platforms need Node.js **22.12+** from
 [nodejs.org](https://nodejs.org/en/download) and one authenticated Agent CLI.
 Reuse the CLI you already work in; Argus does not require a separate account.
+Docker is not required for a normal Argus installation; it is only an optional
+prerequisite for the separate Harbor evaluation integration.
 
 | Agent CLI | Backend | Install | Authenticate |
 |---|---|---|---|
@@ -479,11 +493,3 @@ logs.
   Argus directly.
 - Use `argus --config-help` to check the effective backend/model before blaming
   setup or authentication.
-
-## WeChat community
-
-Scan the QR code below to join the Argus community. The expiry date is printed in the image; if it has expired, open an Issue and ask the maintainers for the latest code.
-
-<p align="center">
-  <img src="docs/assets/argus-wechat-group.jpg" width="360" alt="Argus WeChat community QR code">
-</p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,11 +58,24 @@ Manager/Planner/Engineer/Reviewer 运行时作为自定义 Agent 直接调用。
 **Code Agent 插件：** 可通过打包的 MCP bridge 和宿主 Skills 使用 Argus，不修改
 核心 runtime。参见 **[插件快速入门](docs/plugin.md)**。
 
+## 微信群
+
+扫码加入 Argus 交流群；点击图片可以查看原图。二维码有效期以图片中的提示为准；
+如果已经过期，请在 Issue 中联系维护者更新。
+
+<p align="center">
+  <a href="docs/assets/argus-wechat-group.jpg">
+    <img src="docs/assets/argus-wechat-group.jpg" width="360" alt="Argus 微信交流群二维码">
+  </a>
+</p>
+
 ## 快速安装
 
 请只使用当前操作系统对应的一组命令，不要混用。所有平台都需要从
 [nodejs.org](https://nodejs.org/en/download) 安装 Node.js **22.12+**，并准备一个
 已完成鉴权的 Agent CLI。直接复用你日常使用的 CLI；Argus 没有单独账户。
+普通 Argus 安装不需要 Docker；只有单独的 Harbor 评测集成可能把 Docker 作为可选
+环境依赖。
 
 | Agent CLI | Backend | 安装 | 鉴权 |
 |---|---|---|---|
@@ -448,11 +461,3 @@ Linux 请先停止 Argus、保留所需工作，再删除 `$HOME/Argus` checkout
 - `argus doctor --advisor none --verify` 只做确定性诊断；需要本机 Agent 直接检查和
   修复 Argus 时使用 `argus doctor`。
 - 用 `argus --config-help` 检查实际 backend/model，再判断 setup 或鉴权是否失败。
-
-## 微信群
-
-扫码加入 Argus 交流群。二维码有效期以图片中的提示为准；如果已经过期，请在 Issue 中联系维护者更新。
-
-<p align="center">
-  <img src="docs/assets/argus-wechat-group.jpg" width="360" alt="Argus 微信交流群二维码">
-</p>

--- a/tests/test_install_documentation.py
+++ b/tests/test_install_documentation.py
@@ -90,3 +90,19 @@ def test_install_guides_cover_updates_paths_models_and_doctor_semantics() -> Non
     assert "\npip install " not in update
 
     assert "If the Releases page has no matching installer asset" in desktop
+
+
+def test_readmes_surface_the_wechat_qr_before_installation() -> None:
+    asset = ROOT / "docs" / "assets" / "argus-wechat-group.jpg"
+    assert asset.is_file()
+    assert asset.stat().st_size > 100_000
+
+    for name, heading in (
+        ("README.md", "## WeChat community"),
+        ("README.zh-CN.md", "## 微信群"),
+    ):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert text.count(heading) == 1
+        assert text.count('src="docs/assets/argus-wechat-group.jpg"') == 1
+        assert text.index(heading) < text.index("## Quick Install" if name == "README.md" else "## 快速安装")
+        assert "Docker" in text


### PR DESCRIPTION
## Summary
- move the WeChat QR section before Quick Install so it is visible without scrolling to the end
- make the image clickable at full size
- clarify that normal Argus installation does not require Docker; Docker is only optional for Harbor evaluation
- add documentation regression coverage for asset presence, placement, and Docker clarity

## Validation
- 129 install/Doctor/Plugin/documentation tests passed on both repository trees
- Ruff and diff checks passed
- candidate product trees pass the private/public parity checker
- raw QR asset returns HTTP 200 (`image/jpeg`, 132425 bytes)