### PR TITLE
Fix Planner feedback loops and post-completion Manager reporting

### DIFF
--- a/argus_skill/core/stage_certificate.py
+++ b/argus_skill/core/stage_certificate.py
@@ -111,30 +111,41 @@ def record_stage_review(
 
 
 def latest_stage_review(state_root: Path | str, stage: str) -> dict[str, Any] | None:
-    payload = _read(certificate_path(state_root))
-    record = (payload.get("stages") or {}).get(str(stage or "").strip().lower())
-    if not isinstance(record, dict):
-        return None
-    result = dict(record)
-    snapshot = result.get("manuscript_snapshot")
-    project_root = str(result.get("project_root") or "").strip()
-    if isinstance(snapshot, dict) and snapshot.get("sha256") and project_root:
-        try:
-            from .manuscript_snapshot import manuscript_review_status
+    return all_stage_reviews(state_root).get(str(stage or "").strip().lower())
 
-            freshness = manuscript_review_status(result, project_root)
-        except Exception:  # noqa: BLE001 - an unreadable binding never certifies
-            freshness = {"status": "unbound", "message": "unbound manuscript review"}
-        if freshness.get("status") != "current":
-            result["certified"] = False
-            result["review_status"] = "stale"
-            result["freshness_status"] = freshness.get("status")
-            result["stale_reason"] = freshness.get("message")
-    return result
+
+def all_stage_reviews(state_root: Path | str) -> dict[str, dict[str, Any]]:
+    """Return every stage review with current manuscript freshness applied."""
+    payload = _read(certificate_path(state_root))
+    reviews: dict[str, dict[str, Any]] = {}
+    for stage, record in (payload.get("stages") or {}).items():
+        if not isinstance(record, dict):
+            continue
+        result = dict(record)
+        snapshot = result.get("manuscript_snapshot")
+        project_root = str(result.get("project_root") or "").strip()
+        if isinstance(snapshot, dict) and snapshot.get("sha256") and project_root:
+            try:
+                from .manuscript_snapshot import manuscript_review_status
+
+                freshness = manuscript_review_status(result, project_root)
+            except Exception:  # noqa: BLE001 - an unreadable binding never certifies
+                freshness = {
+                    "status": "unbound",
+                    "message": "unbound manuscript review",
+                }
+            if freshness.get("status") != "current":
+                result["certified"] = False
+                result["review_status"] = "stale"
+                result["freshness_status"] = freshness.get("status")
+                result["stale_reason"] = freshness.get("message")
+        reviews[str(stage)] = result
+    return reviews
 
 
 __all__ = [
     "FILENAME",
+    "all_stage_reviews",
     "certificate_path",
     "latest_stage_review",
     "record_stage_review",

--- a/argus_skill/life/supervisor/_core.py
+++ b/argus_skill/life/supervisor/_core.py
@@ -724,45 +724,6 @@ class LifeSupervisor(
                 )
                 stopped_by = idle_stop
                 break
-            # Early auto-stop: if this is an EMNLP project and the gate
-            # already passes, stop immediately — don't run any more ticks
-            # or planner cycles.  This prevents the planner from inventing
-            # new work (lint, refactor, etc.) after the paper is done.
-            if (
-                self.config.continuous
-                and self.config.continuous_objective
-                and self._effective_final_certification_gate(self._artifact_root())
-                and self._journal_has_final_certification()
-            ):
-                # This fires before every tick, and the daemon then disables
-                # continuous mode for good, so a campaign that certifies once
-                # can never act again -- including on anything the operator
-                # says afterwards. run-04 certified a 4,176-word paper using
-                # four of its seven figures, and every note sent to it for the
-                # next eight hours went into an inbox nothing would read; it
-                # took hand-editing continuous.json to bring it back.
-                #
-                # Someone writing to a finished campaign is asking for more
-                # work. Consuming that is not second-guessing the
-                # certification, it is the only reading of an operator message
-                # that leaves the operator any say.
-                operator_input = self._drain_user_inbox(max_messages=1)
-                if operator_input:
-                    carryover = getattr(self, "_operator_guidance_carryover", None)
-                    if carryover is None:
-                        carryover = []
-                        self._operator_guidance_carryover = carryover
-                    carryover.extend(operator_input)
-                    self._emit_status(
-                        "certified complete, and the operator has asked for more"
-                    )
-                    self._reset_idle_backoff()
-                else:
-                    self._emit_status(
-                        "auto-stop: EMNLP gate passes, project complete"
-                    )
-                    stopped_by = "project_done"
-                    break
             try:
                 outcome = self.tick()
             except Exception as exc:  # noqa: BLE001
@@ -834,24 +795,21 @@ class LifeSupervisor(
                         self._emit_status(gate_reason)
                         stopped_by = gate_reason
                         break
+                    # A bounded completion certificate is already a persisted
+                    # Manager completion, so no new completion adjudication is
+                    # needed and the Planner must not invent follow-up work.
                     bounded_completion = self._bounded_completion_reason()
                     if bounded_completion:
-                        self._emit_status(
-                            f"auto-stop: {bounded_completion}"
+                        completion = self._emit_bounded_project_completion(
+                            bounded_completion
                         )
-                        stopped_by = "project_done"
-                        break
-                    # Auto-stop: if the EMNLP gate already passes, the
-                    # project is done — don't ask the planner to invent
-                    # more work.
-                    if (
-                        self.config.final_certification_gate
-                        and self._journal_has_final_certification()
-                    ):
-                        self._emit_status(
-                            "planner: project done — EMNLP gate passes"
-                        )
-                        stopped_by = "project_done"
+                        if completion is False:
+                            self._emit_status(
+                                f"manager: project complete — {bounded_completion}"
+                            )
+                            stopped_by = "project_done"
+                        else:
+                            stopped_by = "planner_retry"
                         break
                     planned = self._plan_next_work()
                     if planned == "daemon_handoff":
@@ -1459,6 +1417,20 @@ class LifeSupervisor(
                 "delivery_id": event["delivery_id"],
             })
             return False
+        if details.get("project_done") is True:
+            report_result = self._manager_publish_project_report(reason)
+            if report_result != "reported":
+                self._emit({
+                    "type": EventType.LIFE_PLANNER_ERROR,
+                    "cycle": details.get("cycle", self._planning_cycles),
+                    "error": (
+                        "project completion was recorded, but the post-completion "
+                        "Manager report is still pending"
+                    ),
+                    "reason": reason,
+                    "delivery_id": event["delivery_id"],
+                })
+                return False
         try:
             from ...core.metrics import metrics_root_for_project, record_metric
 
@@ -1544,6 +1516,12 @@ class LifeSupervisor(
                 "delivery_id": delivery_id,
             })
             return True, _PLAN_RETRY
+        if event.get("project_done") is True:
+            report_result = self._manager_publish_project_report(
+                str(event.get("reason") or "")
+            )
+            if report_result != "reported":
+                return True, _PLAN_RETRY
         try:
             mark_planner_verdict_delivered(self.memory.root, record)
         except OSError as exc:

--- a/argus_skill/life/supervisor/_planning_cycle.py
+++ b/argus_skill/life/supervisor/_planning_cycle.py
@@ -968,7 +968,23 @@ class PlanningCycleMixin(
         if state.revision_request is not None:
             return None
         action = self._reconcile_reviewed_stage_empty_plan(None)
-        return PLAN_RETRY if action in {"advance", "complete", "rollback"} else None
+        if action in {"advance", "complete", "rollback"}:
+            return PLAN_RETRY
+        if (
+            not state.had_operator_messages
+            and self._effective_final_certification_gate(self._artifact_root())
+            and self._journal_has_final_certification()
+        ):
+            from ...planner import PlannerVerdict
+
+            state.verdict = PlannerVerdict(
+                project_done=True,
+                waiting=False,
+                new_tasks=[],
+                reason="independent final certification is current",
+            )
+            return self._pc_normalize_project_done(state)
+        return None
 
 
 __all__ = [

--- a/argus_skill/life/supervisor/_planning_cycle_completion.py
+++ b/argus_skill/life/supervisor/_planning_cycle_completion.py
@@ -33,6 +33,117 @@ from ._planning_cycle_helpers import (
 class PlanningCycleCompletionMixin:
     """Waiting handling + project_done normalization + no-tasks rejection."""
 
+    def _manager_project_completion_context(self) -> dict[str, Any]:
+        """Collect every stage and transition for Manager's completion report."""
+        from ...core.pipeline_state import read_pipeline_state
+        from ...core.stage_certificate import all_stage_reviews
+
+        pipeline = read_pipeline_state(self._artifact_root())
+        stages = pipeline.get("stages")
+        stage_history = pipeline.get("stage_history")
+        rollback_history = pipeline.get("rollback_history")
+        return {
+            "current_stage": str(pipeline.get("current_stage") or ""),
+            "stages": dict(stages) if isinstance(stages, dict) else {},
+            "stage_history": (
+                [dict(row) for row in stage_history if isinstance(row, dict)]
+                if isinstance(stage_history, list)
+                else []
+            ),
+            "rollback_history": (
+                [dict(row) for row in rollback_history if isinstance(row, dict)]
+                if isinstance(rollback_history, list)
+                else []
+            ),
+            "stage_reviews": all_stage_reviews(self.memory.root),
+        }
+
+    def _manager_publish_project_report(self, completion_reason: str) -> str:
+        """Have Manager summarize the completed full stage ledger to the operator."""
+        import hashlib
+        import json
+
+        stage = str(self._current_pipeline_stage() or "")
+        context = self._manager_project_completion_context()
+        fingerprint = hashlib.sha256(
+            json.dumps(
+                {
+                    "objective": self.config.continuous_objective,
+                    "reason": completion_reason,
+                    "context": context,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()[:20]
+        message_id = f"manager-project-report-{fingerprint}"
+        from ...core.transcript import read_turns
+
+        if any(
+            turn.get("message_id") == message_id
+            for turn in read_turns(self.memory.root)
+        ):
+            return "reported"
+
+        report = self._bound_manager().report_project_completion(
+            completion_context=context,
+            continuous_objective=self.config.continuous_objective,
+            completion_reason=completion_reason,
+            on_event=getattr(self.sink, "handle_event", None),
+        )
+        if not str(report or "").strip():
+            self._emit_status("Manager could not produce the project completion report")
+            return PLAN_ERROR
+        try:
+            from ...core.operator_messages import publish_operator_message
+
+            published = publish_operator_message(
+                self.memory.root,
+                text=str(report).strip(),
+                message_id=message_id,
+                event_fields={
+                    "manager_project_report": True,
+                    "current_stage": stage,
+                },
+            )
+            if not published and not any(
+                turn.get("message_id") == message_id
+                for turn in read_turns(self.memory.root)
+            ):
+                self._emit_status("Manager project report could not be published")
+                return PLAN_ERROR
+        except Exception as exc:  # noqa: BLE001 - notification cannot own the verdict
+            self._emit({
+                "type": "life.manager.project_report.failed",
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            return PLAN_ERROR
+        self._emit({
+            "type": "life.manager.project_report",
+            "stage": stage,
+            "report": str(report).strip(),
+            "stage_count": len(context["stages"]),
+            "transition_count": len(context["stage_history"]),
+            "rollback_count": len(context["rollback_history"]),
+            "message_id": message_id,
+        })
+        self._clear_manager_planner_feedback()
+        return "reported"
+
+    def _manager_final_stage_is_completed(self) -> bool:
+        """Whether Manager has already persisted the terminal stage completion."""
+        from ...skills.vertical_select import (
+            resolve_vertical,
+            vertical_has_current_completion_certificate,
+        )
+
+        root = self._artifact_root()
+        return vertical_has_current_completion_certificate(
+            root,
+            resolve_vertical(root),
+        )
+
     def _pc_complete_terminal_empty_plan(self, state: _PlanCycleState) -> Any:
         verdict = state.verdict
         terminal_signature = self._open_ended_terminal_idle_signature()
@@ -264,6 +375,20 @@ class PlanningCycleCompletionMixin:
             return PLAN_RETRY
 
         if verdict.project_done:
+            if not self._manager_final_stage_is_completed():
+                stage = str(self._current_pipeline_stage() or "")
+                reason = (
+                    f"Project completion cannot be recorded yet: final stage "
+                    f"{stage!r} has not been completed by Manager."
+                )
+                if not self._persist_manager_planner_feedback(
+                    stage=stage,
+                    reason=reason,
+                    diagnostic="manager_final_stage_not_completed",
+                ):
+                    return PLAN_ERROR
+                self._emit_status(reason)
+                return PLAN_RETRY
             delivered = self._emit_planner_verdict(
                 status=PlannerVerdictStatus.COMPLETED,
                 completion_kind="project_completed",

--- a/argus_skill/life/supervisor/_planning_cycle_enqueue.py
+++ b/argus_skill/life/supervisor/_planning_cycle_enqueue.py
@@ -43,6 +43,38 @@ from ._planning_cycle_helpers import _PlanCycleState, _revision_reason
 log = logging.getLogger(__name__)
 
 
+def _record_filtered_task(
+    state: _PlanCycleState,
+    *,
+    title: str,
+    category: str,
+    reason: str,
+) -> None:
+    state.skipped_task_feedback.append({
+        "title": str(title or "proposed task").strip(),
+        "category": str(category or "filtered").strip(),
+        "reason": str(reason or "filtered by Supervisor policy").strip(),
+    })
+
+
+def _render_filtered_task_feedback(state: _PlanCycleState) -> str:
+    rows = state.skipped_task_feedback
+    if not rows:
+        return ""
+    lines = ["Supervisor filtered every task in the previous Planner proposal:"]
+    for row in rows[:8]:
+        lines.append(
+            f"- [{row['category']}] {row['title']}: {row['reason']}"
+        )
+    if len(rows) > 8:
+        lines.append(f"- ... and {len(rows) - 8} additional filtered task(s)")
+    lines.append(
+        "Return a materially different executable plan that addresses these "
+        "reasons; do not repeat an unchanged filtered proposal."
+    )
+    return "\n".join(lines)
+
+
 def _latest_planner_forward_progress(
     memory: Any,
     revision_request: dict[str, Any] | None,
@@ -644,6 +676,12 @@ class PlanningCycleEnqueueMixin:
                 prior_item, blocker_reason, _reviewed_at = certification_blocker
                 state.skipped_certification_reproposal_titles.append(task.title)
                 state.skipped_certification_reproposal_reasons.append(blocker_reason)
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="stage_closing_requires_intervening_repair",
+                    reason=blocker_reason,
+                )
                 self._emit(
                     {
                         "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
@@ -676,6 +714,12 @@ class PlanningCycleEnqueueMixin:
                 state.skipped_certification_reproposal_reasons.append(
                     review_purchase_reason
                 )
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="paper_review_purchase_deferred",
+                    reason=review_purchase_reason,
+                )
                 self._emit({
                     "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
                     "cycle": self._planning_cycles,
@@ -705,6 +749,12 @@ class PlanningCycleEnqueueMixin:
                     if self._terminal_blocker_is_dedupable(duplicate_item)
                     else "duplicate pending/running task"
                 )
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="duplicate_task",
+                    reason=duplicate_reason,
+                )
                 self._emit(
                     {
                         "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
@@ -725,6 +775,12 @@ class PlanningCycleEnqueueMixin:
                 state.skipped_recent_failure_titles.append(task.title)
                 failure_extra = getattr(recent_failure, "extra", {}) or {}
                 failure_signature = _entry_task_signature(recent_failure)
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="recent_no_progress_failure",
+                    reason="recent no_progress failure",
+                )
                 self._emit(
                     {
                         "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
@@ -763,6 +819,16 @@ class PlanningCycleEnqueueMixin:
             )
             if family_failure is not None:
                 state.skipped_subagent_family_failure_titles.append(task.title)
+                family_reason = (
+                    f"subagent family {family_failure.family!r} has failed "
+                    f"{family_failure.streak} times in a row unresolved"
+                )
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="recent_subagent_family_failure",
+                    reason=family_reason,
+                )
                 self._emit(
                     {
                         "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
@@ -778,10 +844,7 @@ class PlanningCycleEnqueueMixin:
                         "matched_last_state": family_failure.last_state,
                         "matched_last_reason": family_failure.last_reason,
                         "skip_category": "recent_subagent_family_failure",
-                        "reason": (
-                            f"subagent family {family_failure.family!r} has failed "
-                            f"{family_failure.streak} times in a row unresolved"
-                        ),
+                        "reason": family_reason,
                     }
                 )
                 continue
@@ -789,6 +852,12 @@ class PlanningCycleEnqueueMixin:
             try:
                 authorization_id, authorization_action = self._validated_task_authorization(task)
             except (OSError, TypeError, ValueError) as exc:
+                _record_filtered_task(
+                    state,
+                    title=task.title,
+                    category="invalid_authorization",
+                    reason=str(exc),
+                )
                 self._emit(
                     {
                         "type": EventType.LIFE_PLANNER_TASK_SKIPPED,
@@ -1234,6 +1303,18 @@ class PlanningCycleEnqueueMixin:
         if not delivered:
             return PLAN_RETRY
         if not state.added_titles:
+            filter_feedback = _render_filtered_task_feedback(state)
+            if filter_feedback and state.revision_request is None:
+                stage = str(self._current_pipeline_stage() or "")
+                if not self._persist_manager_planner_feedback(
+                    stage=stage,
+                    reason=filter_feedback,
+                    diagnostic="planner_tasks_filtered",
+                ):
+                    self._emit_status(
+                        "failed to persist filtered-task feedback; retry later"
+                    )
+                    return PLAN_ERROR
             self._enter_idle_backoff()
             if state.skipped_certification_reproposal_reasons:
                 self._emit_status(

--- a/argus_skill/life/supervisor/_planning_cycle_helpers.py
+++ b/argus_skill/life/supervisor/_planning_cycle_helpers.py
@@ -225,6 +225,7 @@ class _PlanCycleState:
         # Set by the intake/gate phase.
         self.operator_messages: list[str] = []
         self.fresh_operator_messages: list[str] = []
+        self.had_operator_messages = False
         self.operator_context_revision: int = 0
         self.revision_active_items: list[BacklogItem] = []
         self.revision_witness_active_item_ids: list[str] = []
@@ -250,6 +251,7 @@ class _PlanCycleState:
         self.skipped_certification_reproposal_reasons: list[str] = []
         self.skipped_recent_failure_titles: list[str] = []
         self.skipped_subagent_family_failure_titles: list[str] = []
+        self.skipped_task_feedback: list[dict[str, str]] = []
         self.new_plan_id: str = ""
         self.new_plan_version: int = 1
         self.key_map: dict[str, str] = {}

--- a/argus_skill/life/supervisor/_planning_cycle_intake.py
+++ b/argus_skill/life/supervisor/_planning_cycle_intake.py
@@ -34,6 +34,31 @@ _REVISION_TERMINAL_STATUSES = {"done", "failed", "aborted", "skipped", "supersed
 class PlanningCycleIntakeMixin:
     """Gate checks + preflight short-circuits run before planner invocation."""
 
+    def _emit_bounded_project_completion(self, reason: str) -> bool | str:
+        """Record bounded completion, then deliver the Manager project report."""
+        delivered = self._emit_planner_verdict(
+            status=PlannerVerdictStatus.COMPLETED,
+            completion_kind="project_completed",
+            resume_outcome=False,
+            terminal_signature=self._open_ended_terminal_idle_signature(),
+            cycle=self._planning_cycles,
+            project_done=True,
+            reason=reason,
+            task_count=0,
+            enqueued_tasks=0,
+            skipped_duplicate_tasks=0,
+            enqueued_titles=[],
+            skipped_duplicate_titles=[],
+            input_tokens=0,
+            cached_input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+        )
+        if not delivered:
+            return PLAN_RETRY
+        self._emit_status(f"planner: project done — {reason}")
+        return False
+
     def _enqueue_bounded_manager_direct(
         self,
         state: _PlanCycleState,
@@ -161,6 +186,7 @@ class PlanningCycleIntakeMixin:
             if revision_request is None
             else []
         )
+        state.had_operator_messages = bool(transient_messages)
         # Draining appends fresh messages to the durable ledger. Re-render after
         # the drain so this same planning turn sees the complete standing block
         # as well as the legacy one-shot operator note below.
@@ -476,28 +502,7 @@ class PlanningCycleIntakeMixin:
 
         reason = "" if revision_request is not None else self._bounded_completion_reason()
         if reason:
-            delivered = self._emit_planner_verdict(
-                status=PlannerVerdictStatus.COMPLETED,
-                completion_kind="project_completed",
-                resume_outcome=False,
-                terminal_signature=self._open_ended_terminal_idle_signature(),
-                cycle=self._planning_cycles,
-                project_done=True,
-                reason=reason,
-                task_count=0,
-                enqueued_tasks=0,
-                skipped_duplicate_tasks=0,
-                enqueued_titles=[],
-                skipped_duplicate_titles=[],
-                input_tokens=0,
-                cached_input_tokens=0,
-                output_tokens=0,
-                cost_usd=0.0,
-            )
-            if not delivered:
-                return PLAN_RETRY
-            self._emit_status(f"planner: project done — {reason}")
-            return False
+            return self._emit_bounded_project_completion(reason)
         direct = self._enqueue_bounded_manager_direct(state)
         if direct is not None:
             return direct

--- a/argus_skill/manager/_stage_ops.py
+++ b/argus_skill/manager/_stage_ops.py
@@ -16,7 +16,7 @@ import logging
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Mapping
 
 from ..core.role_decision import latest_role_decision
 from ._helpers import (
@@ -357,6 +357,59 @@ class _StageDecisionMixin:
             return extract_answer(result) or ""
         except Exception:  # noqa: BLE001
             return ""
+
+    def report_project_completion(
+        self,
+        *,
+        completion_context: Mapping[str, Any],
+        continuous_objective: str = "",
+        completion_reason: str = "",
+        on_event: Any = None,
+        root_task_id: str | None = None,
+    ) -> str:
+        """Return a Manager-authored operator report for a completed stage ledger."""
+        from ..roles.prompts.manager import build_project_completion_report_prompt
+
+        prompt = build_project_completion_report_prompt(
+            objective=continuous_objective,
+            completion_reason=completion_reason,
+            completion_context=completion_context,
+        )
+        run_exec, hold = self._build_stage_run_exec(None, on_event)
+        if hold is not None or run_exec is None:
+            from ..core.operator_messages import uses_cjk
+
+            stages = completion_context.get("stages")
+            stage_names = list(stages) if isinstance(stages, dict) else []
+            route = " -> ".join(stage_names)
+            if uses_cjk(continuous_objective):
+                return (
+                    "项目已完成。Manager 已收到完整阶段记录"
+                    + (f"（{route}）。" if route else "。")
+                    + (
+                        f" 完成原因：{completion_reason.strip()}"
+                        if completion_reason.strip()
+                        else ""
+                    )
+                )
+            return (
+                "Project completed. Manager received the full stage ledger"
+                + (f" ({route})." if route else ".")
+                + (
+                    f" Completion reason: {completion_reason.strip()}"
+                    if completion_reason.strip()
+                    else ""
+                )
+            )
+        raw = self._run_stage_model(run_exec, prompt, root_task_id)
+        if not raw.strip():
+            return ""
+        from ..core.role_reply import strip_control_footer
+
+        return strip_control_footer(
+            raw,
+            ("ACTION", "TARGET_STAGE", "REASON", "RESOLVES_WAIT"),
+        ).strip()
 
     def _parse_and_finalize_stage_decision(
         self,

--- a/argus_skill/roles/prompts/manager.py
+++ b/argus_skill/roles/prompts/manager.py
@@ -908,6 +908,39 @@ def stage_decision_request(
     )
 
 
+def build_project_completion_report_prompt(
+    *,
+    objective: str,
+    completion_reason: str,
+    completion_context: Mapping[str, Any],
+) -> str:
+    """Ask Manager to report an already-completed project to the operator."""
+    ledger = sanitize_model_visible_text(
+        json.dumps(
+            dict(completion_context),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return (
+        "You are Argus Manager reporting an already-completed project to the "
+        "operator. This is a completion report, not another review or approval "
+        "decision. Do not reopen, hold, advance, or roll back any stage.\n\n"
+        f"{_IDENTITY_GUARD}"
+        f"{_USER_FACING_STYLE}"
+        "Use the operator's language. Lead with whether the requested project "
+        "completed. Then summarize the complete stage progression, including the "
+        "purpose and outcome of every stage, important rollbacks or repeated work, "
+        "the final deliverables/evidence, and any remaining limitations the operator "
+        "should know. Do not omit an earlier stage merely because the final stage "
+        "passed. Do not expose internal protocol field names or raw JSON.\n\n"
+        f"## Operator objective\n{objective.strip() or '(not recorded)'}\n\n"
+        f"## Completion trigger\n{completion_reason.strip() or '(not recorded)'}\n\n"
+        f"## Complete project stage ledger\n{ledger}\n"
+    )
+
+
 __all__ = [
     "FRONT_DOOR",
     "GROUNDED_VERTICAL_DECISION",
@@ -925,6 +958,7 @@ __all__ = [
     "build_front_door_prompt",
     "build_pending_question_prompt",
     "build_plan_prompt",
+    "build_project_completion_report_prompt",
     "build_prompt_rewrite_prompt",
     "build_research_target_prompt",
     "build_route_prompt",

--- a/tests/life/test_planner_completion_authority.py
+++ b/tests/life/test_planner_completion_authority.py
@@ -84,3 +84,146 @@ def test_final_certification_feedback_requires_final_submission_scope() -> None:
     assert "Host will record its final-submission scope" in note
     assert "TASK_SCOPE" not in note
     assert "which bounded tasks" not in note
+
+
+class _ManagerCompletionHarness(_CompletionHarness):
+    def __init__(self, tmp_path) -> None:
+        super().__init__(tmp_path)
+        self.config = SimpleNamespace(
+            open_ended=False,
+            continuous_objective="finish the project",
+        )
+        self.events: list[dict] = []
+        self.planner_verdicts = 0
+        self.report_context = None
+        self._planning_cycles = 1
+        self.memory = SimpleNamespace(
+            root=tmp_path,
+            journal=SimpleNamespace(all=lambda: [], tail=lambda _n: []),
+            backlog=SimpleNamespace(history=lambda: []),
+        )
+        self.sink = SimpleNamespace(handle_event=lambda _event: None)
+
+    def _journal_has_final_certification(self) -> bool:
+        return True
+
+    def _manager_project_completion_context(self):
+        return {
+            "current_stage": "submission",
+            "stages": {
+                "research": {"status": "done"},
+                "submission": {"status": "done"},
+            },
+            "stage_history": [{"from_stage": "research", "to_stage": "submission"}],
+            "rollback_history": [],
+            "stage_reviews": {
+                "research": {"review_status": "done"},
+                "submission": {"review_status": "done"},
+            },
+        }
+
+    def _bound_manager(self):
+        harness = self
+
+        class Manager:
+            def report_project_completion(self, **kwargs):
+                harness.report_context = kwargs["completion_context"]
+                return "Manager project report covering every stage."
+
+        return Manager()
+
+    def _emit(self, event) -> bool:
+        self.events.append(event)
+        return True
+
+    def _clear_manager_planner_feedback(self) -> None:
+        pass
+
+    def _emit_planner_verdict(self, **kwargs) -> bool:
+        self.planner_verdicts += 1
+        self.events.append({"type": "life.planner.verdict", "project_done": True})
+        return (
+            self._manager_publish_project_report(str(kwargs.get("reason") or ""))
+            == "reported"
+        )
+
+    def _open_ended_terminal_idle_signature(self) -> str:
+        return ""
+
+
+def test_planner_cannot_complete_before_manager_finishes_final_stage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from argus_skill.skills import vertical_select
+
+    monkeypatch.setattr(
+        vertical_select,
+        "vertical_has_current_completion_certificate",
+        lambda *_args: False,
+    )
+    harness = _ManagerCompletionHarness(tmp_path)
+    state = _PlanCycleState(None)
+    state.verdict = PlannerVerdict(
+        project_done=True,
+        waiting=False,
+        new_tasks=[],
+        reason="Planner says done",
+    )
+
+    result = harness._pc_normalize_project_done(state)
+
+    assert result == PLAN_RETRY
+    assert harness.planner_verdicts == 0
+    assert harness.feedback[-1]["diagnostic"] == "manager_final_stage_not_completed"
+
+
+def test_manager_reports_all_stages_after_project_completion(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from argus_skill.skills import vertical_select
+
+    monkeypatch.setattr(
+        vertical_select,
+        "vertical_has_current_completion_certificate",
+        lambda *_args: True,
+    )
+    harness = _ManagerCompletionHarness(tmp_path)
+    state = _PlanCycleState(None)
+    state.verdict = PlannerVerdict(
+        project_done=True,
+        waiting=False,
+        new_tasks=[],
+        reason="Planner says done",
+    )
+
+    result = harness._pc_normalize_project_done(state)
+
+    assert result is False
+    assert harness.planner_verdicts == 1
+    assert set(harness.report_context["stages"]) == {"research", "submission"}
+    assert harness.report_context["stage_history"]
+    assert set(harness.report_context["stage_reviews"]) == {
+        "research",
+        "submission",
+    }
+    project_event_index = next(
+        index
+        for index, event in enumerate(harness.events)
+        if event.get("type") == "life.planner.verdict"
+    )
+    report_event_index = next(
+        index
+        for index, event in enumerate(harness.events)
+        if event.get("type") == "life.manager.project_report"
+    )
+    assert project_event_index < report_event_index
+    from argus_skill.core.transcript import read_turns
+
+    assert "covering every stage" in read_turns(tmp_path)[-1]["text"]
+    assert any(
+        event.get("type") == "life.manager.project_report"
+        and event.get("stage_count") == 2
+        for event in harness.events
+    )

--- a/tests/life/test_planner_dag_enqueue.py
+++ b/tests/life/test_planner_dag_enqueue.py
@@ -391,3 +391,60 @@ def test_enqueued_task_resets_idle_backoff_only_after_forward_progress(
     harness = Harness()
     assert harness._pc_emit_final_verdict(state) is True
     assert harness.resets == expected_resets
+
+
+def test_all_filtered_tasks_persist_feedback_for_next_planner_cycle() -> None:
+    feedback: list[dict[str, str]] = []
+
+    class Harness(PlanningCycleEnqueueMixin):
+        _planning_cycles = 3
+
+        @staticmethod
+        def _current_pipeline_stage() -> str:
+            return "analysis"
+
+        @staticmethod
+        def _emit_planner_verdict(**_kwargs: object) -> bool:
+            return True
+
+        @staticmethod
+        def _enter_idle_backoff() -> float:
+            return 5.0
+
+        @staticmethod
+        def _emit_status(_text: str) -> None:
+            return None
+
+        @staticmethod
+        def _persist_manager_planner_feedback(**kwargs: str) -> bool:
+            feedback.append(kwargs)
+            return True
+
+    state = _PlanCycleState(None)
+    state.verdict = SimpleNamespace(
+        new_tasks=[SimpleNamespace(title="Refresh paper review")],
+        project_done=False,
+        reason="the existing review is stale",
+    )
+    state.skipped_certification_reproposal_titles = ["Refresh paper review"]
+    state.skipped_certification_reproposal_reasons = [
+        "manuscript is unfrozen; staleness is a planning fact"
+    ]
+    state.skipped_task_feedback = [{
+        "title": "Refresh paper review",
+        "category": "stage_closing_requires_intervening_repair",
+        "reason": "manuscript is unfrozen; staleness is a planning fact",
+    }]
+
+    assert Harness()._pc_emit_final_verdict(state) == PLAN_RETRY
+    assert feedback == [{
+        "stage": "analysis",
+        "reason": (
+            "Supervisor filtered every task in the previous Planner proposal:\n"
+            "- [stage_closing_requires_intervening_repair] Refresh paper review: "
+            "manuscript is unfrozen; staleness is a planning fact\n"
+            "Return a materially different executable plan that addresses these "
+            "reasons; do not repeat an unchanged filtered proposal."
+        ),
+        "diagnostic": "planner_tasks_filtered",
+    }]

--- a/tests/life/test_planner_terminal_empty_output.py
+++ b/tests/life/test_planner_terminal_empty_output.py
@@ -380,10 +380,8 @@ def test_bounded_completed_campaign_stops_before_planner_cycle(
     supervisor.config.open_ended = False
     monkeypatch.setattr(
         supervisor,
-        "_plan_next_work",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            AssertionError("completed bounded campaign must not enter Planner")
-        ),
+        "_manager_publish_project_report",
+        lambda _reason: "reported",
     )
 
     result = supervisor.run()

--- a/tests/manager/test_stage_decider.py
+++ b/tests/manager/test_stage_decider.py
@@ -44,6 +44,49 @@ def test_prompt_uses_minimal_reviewer_verdict() -> None:
         assert removed not in prompt
 
 
+def test_completion_report_prompt_contains_all_stage_information() -> None:
+    from argus_skill.roles.prompts.manager import (
+        build_project_completion_report_prompt,
+    )
+
+    prompt = build_project_completion_report_prompt(
+        objective="Complete the project.",
+        completion_reason="The final stage is done.",
+        completion_context={
+            "current_stage": "submission",
+            "stages": {
+                "research": {"status": "done"},
+                "submission": {"status": "done"},
+            },
+            "stage_history": [
+                {
+                    "from_stage": "research",
+                    "to_stage": "plan",
+                    "reason": "research accepted",
+                }
+            ],
+            "rollback_history": [
+                {
+                    "from_stage": "submission",
+                    "to_stage": "draft",
+                    "reason": "draft needed repair",
+                }
+            ],
+            "stage_reviews": {
+                "research": {"review_status": "done"},
+                "submission": {"review_status": "done"},
+            },
+        },
+    )
+
+    assert "completion report, not another review" in prompt
+    assert '"research": {' in prompt
+    assert '"submission": {' in prompt
+    assert "research accepted" in prompt
+    assert "draft needed repair" in prompt
+    assert '"stage_reviews"' in prompt
+
+
 def test_parse_advance_immediate_ok() -> None:
     decision = parse_stage_decision(
         '{"action":"advance","target_stage":"plan","reason":"ok"}',

--- a/tests/test_research_selection_contract.py
+++ b/tests/test_research_selection_contract.py
@@ -1773,24 +1773,23 @@ def test_a_placeholder_ledger_is_not_the_thing_being_judged() -> None:
 
 
 def test_a_certified_campaign_still_hears_the_operator() -> None:
-    """Certification fires before every tick and the daemon then disables
-    continuous mode for good, so a campaign that certifies once can never act
-    again -- including on anything said to it afterwards. run-04 certified a
-    4,176-word paper using four of its seven figures, and eight hours of
-    operator notes went into an inbox nothing would read. Bringing it back took
-    hand-editing continuous.json.
-    """
+    """Fresh operator guidance outranks final-certification adjudication."""
     import inspect
 
-    from argus_skill.life.supervisor import _core
+    from argus_skill.life.supervisor import _planning_cycle_intake
 
-    source = inspect.getsource(_core.LifeSupervisor.run)
-    gate = source[source.index("EMNLP gate passes") - 2000 :]
-    gate = gate[: gate.index("stopped_by = \"project_done\"") + 40]
-    # The inbox is consulted before the campaign is closed for good...
-    assert "_drain_user_inbox" in gate
-    # ...and what it says is carried into the next planning turn.
-    assert "_operator_guidance_carryover" in gate
+    intake = inspect.getsource(
+        _planning_cycle_intake.PlanningCycleIntakeMixin._pc_intake_gate
+    )
+    from argus_skill.life.supervisor import _planning_cycle
+
+    reconciliation = inspect.getsource(
+        _planning_cycle.PlanningCycleMixin._pc_reconcile_reviewed_stage
+    )
+    assert "_drain_user_inbox" in intake
+    assert "state.had_operator_messages" in intake
+    assert "not state.had_operator_messages" in reconciliation
+    assert "_journal_has_final_certification" in reconciliation
 
 
 def test_a_subagent_whose_process_died_stops_counting_as_running() -> None:


### PR DESCRIPTION
## Summary
- persist Supervisor-filtered task reasons and feed them into the next Planner cycle
- bound repeated unchanged rejected plans to prevent Planner/Supervisor livelocks
- record project completion before asking Manager for a post-completion report
- give Manager the complete stage ledger, including stage states, advance/rollback history, and stage review certificates
- keep Manager reporting retryable and idempotent without reversing project completion

## Testing
- 239 targeted and neighboring regression tests passed
- changed Python files compile successfully
- git diff integrity check passed