### PR TITLE
fix(research): harden draft integrity checks

### DIFF
--- a/argus_skill/verticals/research/figure_tool.py
+++ b/argus_skill/verticals/research/figure_tool.py
@@ -73,9 +73,11 @@ _PAPER_FIGURE_REQUIRED_CONTEXT = (
     Path("paper/style_ref/PAPER_STRUCTURE_BLUEPRINT.md"),
 )
 _PAPER_FIGURE_EVIDENCE_OPTIONS = (
+    Path("paper/claims_to_evidence.tsv"),
     Path("paper/CLAIM_GRAPH.json"),
     Path("paper/artifacts/claims_evidence.tsv"),
     Path("paper/RESULTS_REPORT.md"),
+    Path("research/NARRATIVE_REPORT.md"),
 )
 _PAPER_FIGURE_OPTIONAL_CONTEXT = (
     Path("research/VENUE_PROFILE.json"),

--- a/argus_skill/verticals/research/integrity_check.py
+++ b/argus_skill/verticals/research/integrity_check.py
@@ -21,12 +21,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
 from .integrity_gate import IntegrityIssue, citation_integrity, scorer_integrity
 
 __all__ = ["check_citations", "check_scores", "main"]
+
+_BIBLIOGRAPHY_RE = re.compile(r"\\bibliography\s*\{([^}]+)\}")
+_ADD_BIB_RESOURCE_RE = re.compile(
+    r"\\addbibresource\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}"
+)
+_LATEX_COMMENT_RE = re.compile(r"(?<!\\)%.*?$", re.MULTILINE)
+_INPUT_RE = re.compile(r"\\(?:input|include)\s*\{([^}]+)\}")
 
 
 def _read(path: Path) -> str:
@@ -36,16 +44,137 @@ def _read(path: Path) -> str:
         return ""
 
 
+def _manuscript_tex_paths(root: Path) -> list[Path]:
+    """Return the main manuscript and its project-contained inputs/includes."""
+
+    main = next(
+        (
+            candidate
+            for candidate in (root / "main.tex", root / "submission" / "main.tex")
+            if candidate.is_file()
+        ),
+        None,
+    )
+    if main is None:
+        return sorted(root.rglob("*.tex"))
+
+    root_resolved = root.resolve()
+    document_root = main.parent.resolve()
+    visited: set[Path] = set()
+    paths: list[Path] = []
+
+    def visit(path: Path) -> None:
+        resolved = path.resolve()
+        if resolved in visited:
+            return
+        try:
+            resolved.relative_to(root_resolved)
+        except ValueError:
+            return
+        if not resolved.is_file():
+            return
+        visited.add(resolved)
+        paths.append(resolved)
+        source = _LATEX_COMMENT_RE.sub("", _read(resolved))
+        for match in _INPUT_RE.finditer(source):
+            resource = Path(match.group(1).strip())
+            for candidate in (document_root / resource, resolved.parent / resource):
+                if not candidate.suffix:
+                    candidate = candidate.with_suffix(".tex")
+                candidate = candidate.resolve()
+                try:
+                    candidate.relative_to(root_resolved)
+                except ValueError:
+                    continue
+                if candidate.is_file():
+                    visit(candidate)
+                    break
+
+    visit(main)
+    return paths
+
+
+def _declared_bibliographies(
+    root: Path,
+    tex_paths: list[Path],
+) -> tuple[list[Path], list[IntegrityIssue]]:
+    """Resolve bibliography resources declared by the reachable manuscript."""
+
+    declarations: list[tuple[Path, str]] = []
+    for tex_path in tex_paths:
+        source = _LATEX_COMMENT_RE.sub("", _read(tex_path))
+        for match in _BIBLIOGRAPHY_RE.finditer(source):
+            declarations.extend(
+                (tex_path, item.strip())
+                for item in match.group(1).split(",")
+                if item.strip()
+            )
+        declarations.extend(
+            (tex_path, match.group(1).strip())
+            for match in _ADD_BIB_RESOURCE_RE.finditer(source)
+            if match.group(1).strip()
+        )
+
+    # Keep legacy projects working when their manuscript does not declare a
+    # bibliography explicitly; declaration-aware projects use only named files.
+    if not declarations:
+        return sorted(root.rglob("*.bib")), []
+
+    paths: list[Path] = []
+    issues: list[IntegrityIssue] = []
+    seen: set[tuple[Path, str]] = set()
+    root_resolved = root.resolve()
+    for tex_path, raw_name in declarations:
+        key = (tex_path.resolve(), raw_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        resource = Path(raw_name)
+        if not resource.suffix:
+            resource = resource.with_suffix(".bib")
+        resolved: Path | None = None
+        escaped = False
+        for candidate in (root / resource, tex_path.parent / resource):
+            candidate = candidate.resolve()
+            try:
+                candidate.relative_to(root_resolved)
+            except ValueError:
+                escaped = True
+                continue
+            if candidate.is_file():
+                resolved = candidate
+                break
+        if resolved is not None:
+            if resolved not in paths:
+                paths.append(resolved)
+            continue
+        code = "bibliography_path_escape" if escaped else "missing_bibliography"
+        message = (
+            f"declared bibliography {raw_name!r} resolves outside the paper root"
+            if escaped
+            else f"declared bibliography {raw_name!r} does not exist"
+        )
+        issues.append(IntegrityIssue(code, "blocker", message, raw_name))
+    return paths, issues
+
+
 def check_citations(project_root: Path, *, require_all_cited: bool = False) -> list[IntegrityIssue]:
     paper = project_root / "paper"
     root = paper if paper.is_dir() else project_root
-    tex_sources = [_read(path) for path in sorted(root.rglob("*.tex"))]
-    bib_source = "\n".join(_read(path) for path in sorted(root.rglob("*.bib")))
+    tex_paths = _manuscript_tex_paths(root)
+    tex_sources = [
+        _LATEX_COMMENT_RE.sub("", _read(path))
+        for path in tex_paths
+    ]
+    bib_paths, resource_issues = _declared_bibliographies(root, tex_paths)
+    bib_source = "\n".join(_read(path) for path in bib_paths)
     if not tex_sources and not bib_source:
         return []
-    return citation_integrity(
+    issues = resource_issues + citation_integrity(
         tex_sources, bib_source, require_all_entries_cited=require_all_cited
     )
+    issues.sort(key=lambda issue: (not issue.blocking, issue.code, issue.subject))
+    return issues
 
 
 def _scores_in(path: Path) -> list[float]:

--- a/argus_skill/verticals/research/paper_structural_minimums.py
+++ b/argus_skill/verticals/research/paper_structural_minimums.py
@@ -742,6 +742,17 @@ def validate_paper_structural_minimums(project_root: Path) -> StructuralReport:
                     )
                 )
 
+    if report.figures_missing_files:
+        report.issues.append(
+            StructuralIssue(
+                code="missing_figure_files",
+                detail=(
+                    "figure command(s) reference missing files: "
+                    + ", ".join(report.figures_missing_files[:5])
+                ),
+            )
+        )
+
     unused = _unreferenced_figures(
         paper_dir,
         {Path(ref).name for ref in figure_refs} | {Path(ref).stem for ref in figure_refs},

--- a/argus_skill/verticals/research/stages.py
+++ b/argus_skill/verticals/research/stages.py
@@ -1002,8 +1002,14 @@ def stage_completion_issues(
             for issue in artifact_freshness_issues(project_root)
         )
     if normalized in {"draft", "review", "submission"}:
+        from .integrity_check import check_citations
         from .paper_structural_minimums import validate_paper_structural_minimums
 
+        issues.extend(
+            f"[citation_integrity:{issue.code}] {issue.message}"
+            for issue in check_citations(project_root)
+            if issue.blocking
+        )
         report = validate_paper_structural_minimums(project_root)
         issues.extend(f"[{issue.code}] {issue.detail}" for issue in report.issues)
     if issues:

--- a/tests/skills/test_argument_organization.py
+++ b/tests/skills/test_argument_organization.py
@@ -158,6 +158,19 @@ def test_valid_paper_and_code_organization_map_passes(tmp_path: Path) -> None:
     assert argument_organization_issues(tmp_path) == ()
 
 
+def test_publishable_paper_still_requires_two_accepted_exemplars(
+    tmp_path: Path,
+) -> None:
+    _target(tmp_path)
+    payload = _payload(tmp_path)
+    payload["exemplars"] = payload["exemplars"][:1]
+    _write(tmp_path, payload)
+
+    issues = argument_organization_issues(tmp_path)
+
+    assert any("at least 2 accepted same-area papers" in issue for issue in issues)
+
+
 def test_available_code_requires_real_checkout_and_inspected_files(
     tmp_path: Path,
 ) -> None:

--- a/tests/skills/test_figure_tool.py
+++ b/tests/skills/test_figure_tool.py
@@ -242,6 +242,37 @@ def _seed_frozen_paper_context(root: Path) -> dict[str, Any]:
     return figure_tool.freeze_paper_figure_context(project_root=root)
 
 
+def test_freeze_accepts_canonical_claim_evidence_without_removing_blueprint(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "research").mkdir(parents=True)
+    (tmp_path / "research" / "RESEARCH_BRIEF.md").write_text(
+        "# Brief\n\nStable thesis.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "research" / "NARRATIVE_REPORT.md").write_text(
+        "# Narrative\n\nThe evidence supports the bounded claim.\n",
+        encoding="utf-8",
+    )
+    style = tmp_path / "paper" / "style_ref"
+    style.mkdir(parents=True)
+    (style / "PAPER_STRUCTURE_BLUEPRINT.md").write_text(
+        "# Blueprint\n\nFigure 1 explains the method and result.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "paper" / "claims_to_evidence.tsv").write_text(
+        "claim_id\tevidence\nc1\tresult.json\n",
+        encoding="utf-8",
+    )
+
+    frozen = figure_tool.freeze_paper_figure_context(project_root=tmp_path)
+    paths = {row["path"] for row in frozen["inputs"]}
+
+    assert "paper/style_ref/PAPER_STRUCTURE_BLUEPRINT.md" in paths
+    assert "paper/claims_to_evidence.tsv" in paths
+    assert "research/NARRATIVE_REPORT.md" in paths
+
+
 def _sync_reviewed_candidate(root: Path, index: int) -> dict[str, Any]:
     figures = root / "paper" / "figures"
     figures.mkdir(parents=True, exist_ok=True)

--- a/tests/skills/test_paper_structural_minimums.py
+++ b/tests/skills/test_paper_structural_minimums.py
@@ -158,6 +158,22 @@ End.
     assert "no_appendix_section" in codes
 
 
+def test_no_conclusion_fails(tmp_path: Path) -> None:
+    _seed_minimal_passing_paper(tmp_path)
+    main = tmp_path / "paper" / "main.tex"
+    main.write_text(
+        main.read_text(encoding="utf-8").replace(
+            r"\section{Conclusion}",
+            r"\section{Discussion}",
+        ),
+        encoding="utf-8",
+    )
+
+    report = validate_paper_structural_minimums(tmp_path)
+
+    assert "no_conclusion_section" in {issue.code for issue in report.issues}
+
+
 def test_v1_style_paper_no_figures_no_cites_fails(tmp_path: Path) -> None:
     """The exact v1 failure mode: PDF compiles, refs.bib has entries, but
     the body has 0 \\includegraphics and only 2 \\cite. Gate must fire."""
@@ -494,6 +510,28 @@ def test_includegraphics_referencing_missing_file_does_not_count(tmp_path: Path)
     report = validate_paper_structural_minimums(tmp_path)
     assert report.figures_found == 0
     assert "ghost.pdf" in report.figures_missing_files
+    assert "missing_figure_files" in {issue.code for issue in report.issues}
+
+
+def test_one_real_figure_does_not_hide_another_missing_figure(
+    tmp_path: Path,
+) -> None:
+    _seed_minimal_passing_paper(tmp_path)
+    main = tmp_path / "paper" / "main.tex"
+    main.write_text(
+        main.read_text(encoding="utf-8").replace(
+            r"\includegraphics{figures/fig1.pdf}",
+            "\\includegraphics{figures/fig1.pdf}\n"
+            r"\includegraphics{figures/missing-ablation.pdf}",
+        ),
+        encoding="utf-8",
+    )
+
+    report = validate_paper_structural_minimums(tmp_path)
+
+    assert report.figures_found == 1
+    assert report.figures_missing_files == ["figures/missing-ablation.pdf"]
+    assert "missing_figure_files" in {issue.code for issue in report.issues}
 
 
 def test_image2_entry_with_figure_id_field_classifies(tmp_path: Path) -> None:

--- a/tests/test_research_integrity_check.py
+++ b/tests/test_research_integrity_check.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 from argus_skill.verticals.research import integrity_check as mod
+from argus_skill.verticals.research.stages import stage_completion_issues
 
 GOOD_BIB = (
     "@article{smith2024, author={Smith, Jane and Doe, John}, "
@@ -84,6 +85,90 @@ def test_tex_and_bib_outside_a_paper_dir_are_still_checked(tmp_path: Path) -> No
     (tmp_path / "refs.bib").write_text(GOOD_BIB, encoding="utf-8")
 
     assert mod.main(["citations", "--project-root", str(tmp_path)]) == 2
+
+
+def test_only_main_reachable_tex_is_checked(tmp_path: Path) -> None:
+    root = _paper(
+        tmp_path,
+        r"\cite{smith2024}\bibliography{references}",
+        GOOD_BIB,
+    )
+    build = root / "paper" / "pdf_build"
+    build.mkdir()
+    (build / "stale.tex").write_text(r"\cite{ghost2025}", encoding="utf-8")
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 0
+
+
+def test_reachable_input_is_checked(tmp_path: Path, capsys) -> None:
+    root = _paper(
+        tmp_path,
+        r"\input{sections/body}\bibliography{references}",
+        GOOD_BIB,
+    )
+    sections = root / "paper" / "sections"
+    sections.mkdir()
+    (sections / "body.tex").write_text(r"\cite{ghost2025}", encoding="utf-8")
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 2
+    assert "unresolved_citation" in capsys.readouterr().err
+
+
+def test_addbibresource_selects_the_declared_bibliography(tmp_path: Path) -> None:
+    root = _paper(
+        tmp_path,
+        r"\cite{smith2024}\addbibresource[location=local]{sources.bib}",
+        "@article{unused, author={A}, title={Unused}, year={2024}}",
+    )
+    (root / "paper" / "sources.bib").write_text(GOOD_BIB, encoding="utf-8")
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 0
+
+
+def test_missing_declared_bibliography_fails_even_when_other_bib_exists(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = _paper(
+        tmp_path,
+        r"\cite{smith2024}\bibliography{missing}",
+        GOOD_BIB,
+    )
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 2
+    assert "missing_bibliography" in capsys.readouterr().err
+
+
+def test_declared_bibliography_cannot_escape_paper_root(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = _paper(tmp_path, r"\bibliography{../outside}", GOOD_BIB)
+    (root / "outside.bib").write_text(GOOD_BIB, encoding="utf-8")
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 2
+    assert "bibliography_path_escape" in capsys.readouterr().err
+
+
+def test_commented_bibliography_declaration_is_ignored(tmp_path: Path) -> None:
+    root = _paper(
+        tmp_path,
+        "\\cite{smith2024}\n% \\bibliography{missing}\n",
+        GOOD_BIB,
+    )
+
+    assert mod.main(["citations", "--project-root", str(root)]) == 0
+
+
+def test_late_stages_enforce_citation_integrity(tmp_path: Path) -> None:
+    root = _paper(tmp_path, r"\cite{ghost2025}", GOOD_BIB)
+
+    for stage in ("draft", "review", "submission"):
+        issues = stage_completion_issues(stage, root)
+        assert any(
+            "[citation_integrity:unresolved_citation]" in issue
+            for issue in issues
+        ), (stage, issues)
 
 
 # -- scores -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Restrict citation integrity scanning to the main manuscript and reachable LaTeX inputs.
- Support both `\bibliography{...}` and `\addbibresource{...}`, blocking missing or escaping bibliography paths.
- Enforce citation integrity during Draft, Review, and Submission completion checks.
- Reject missing figure files even when another valid figure exists.
- Accept canonical claim-evidence and narrative-report paths while retaining the structure-blueprint requirement.

All existing research-paper quality gates remain intact, including Figure 1, citation count, Related Work, Conclusion, Appendix, two accepted-paper exemplars, and argument/structure checks.

## Validation

- `pytest`: 6960 passed, 26 skipped
- Targeted Ruff lint: passed
- Full-repository Ruff currently reports one unrelated pre-existing import-order issue in `tests/tools/test_subagent_experiment_preflight.py`.