### PR TITLE
fix: separate research state and evidence roots

### DIFF
--- a/argus_skill/life/supervisor/_planning_cycle_enqueue.py
+++ b/argus_skill/life/supervisor/_planning_cycle_enqueue.py
@@ -145,6 +145,7 @@ def _research_stage_ready_for_close(
             definition,
             stage="research",
             project_root=evidence_root,
+            state_root=state_root,
         )
     except Exception:  # noqa: BLE001 - automatic closing is fail-open to normal planning
         return False

--- a/argus_skill/verticals/research/idea_portfolio.py
+++ b/argus_skill/verticals/research/idea_portfolio.py
@@ -760,9 +760,14 @@ def refresh_idea_portfolio(project_root: Path) -> None:
         pool.update(root, state="draining")
 
 
-def idea_portfolio_completion_issues(project_root: Path) -> tuple[str, ...]:
+def idea_portfolio_completion_issues(
+    project_root: Path,
+    *,
+    state_root: Path | None = None,
+) -> tuple[str, ...]:
+    """Validate repository artifacts under ``project_root`` using state-root policy."""
     project_root = Path(project_root).expanduser().resolve()
-    if not portfolio_required(project_root):
+    if not portfolio_required(state_root or project_root):
         return ()
     active = _active_portfolio(project_root)
     if active is None:

--- a/argus_skill/verticals/research/idea_portfolio.py
+++ b/argus_skill/verticals/research/idea_portfolio.py
@@ -468,7 +468,8 @@ def _ensure_selection_team(
     )
     payload["selection_review_task_ids"] = list(reviews)
     payload["selection_team_id"] = selection_team_id
-    _write_state(project_root, payload)
+    if state != payload:
+        _write_state(project_root, payload)
     return selection_root
 
 

--- a/argus_skill/verticals/research/stages.py
+++ b/argus_skill/verticals/research/stages.py
@@ -1024,7 +1024,10 @@ def stage_completion_issues(
             "research stage requirements cannot be determined because "
             "PIPELINE_STATE.json is missing at the resolved state root",
         )
-    return idea_portfolio_completion_issues(resolved_state_root)
+    return idea_portfolio_completion_issues(
+        project_root,
+        state_root=resolved_state_root,
+    )
 
 
 def iteration_assessment(

--- a/tests/life/test_research_stage_auto_close.py
+++ b/tests/life/test_research_stage_auto_close.py
@@ -18,10 +18,17 @@ def test_research_stage_ready_when_deterministic_blockers_are_empty(
         "argus_skill.verticals._base.load_vertical",
         lambda *_args, **_kwargs: definition,
     )
+    gate_call: dict[str, object] = {}
+
+    def completion_issues(*args, **kwargs):
+        gate_call.update({"args": args, **kwargs})
+        return ()
+
     monkeypatch.setattr(
         "argus_skill.verticals._base.vertical_stage_completion_issues",
-        lambda *_args, **_kwargs: (),
+        completion_issues,
     )
+    state_root = tmp_path / "state"
     evidence_root = tmp_path / "workdir"
     (evidence_root / "research").mkdir(parents=True)
     (evidence_root / "paper").mkdir()
@@ -29,9 +36,15 @@ def test_research_stage_ready_when_deterministic_blockers_are_empty(
     (evidence_root / "paper" / "novelty_audit.md").write_text("positioned\n")
 
     assert module._research_stage_ready_for_close(
-        state_root=tmp_path / "state",
+        state_root=state_root,
         evidence_root=evidence_root,
     )
+    assert gate_call == {
+        "args": (definition,),
+        "stage": "research",
+        "project_root": evidence_root,
+        "state_root": state_root,
+    }
 
 
 def test_research_stage_does_not_close_with_blockers(

--- a/tests/skills/test_research_idea_portfolio.py
+++ b/tests/skills/test_research_idea_portfolio.py
@@ -416,6 +416,44 @@ def test_evidence_selector_can_choose_best_not_earliest(tmp_path: Path) -> None:
     assert pool.read(selection_root)["state"] == "draining"
 
 
+def test_research_gate_separates_state_root_from_project_portfolio(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    state_root = tmp_path / "state"
+    project_root.mkdir()
+    _pipeline(state_root)
+
+    root = ensure_idea_portfolio(project_root, direction="agent reliability")
+    reviewed = _complete_review_set(project_root, root)
+    ensure_idea_portfolio(project_root, direction="agent reliability")
+    _complete_selection(
+        project_root,
+        selected_route=reviewed[0][0],
+        selected_review=reviewed[0][1],
+    )
+
+    state_files = sorted(
+        path.relative_to(state_root).as_posix()
+        for path in state_root.rglob("*")
+        if path.is_file()
+    )
+    assert state_files == [".argus/PIPELINE_STATE.json"]
+    assert stage_completion_issues(
+        "research",
+        project_root,
+        state_root=state_root,
+    ) == ()
+
+    missing_project = tmp_path / "missing-project"
+    missing_project.mkdir()
+    assert stage_completion_issues(
+        "research",
+        missing_project,
+        state_root=state_root,
+    ) == ("research idea portfolio state is missing or invalid",)
+
+
 def test_late_routes_remain_claimable_and_reach_reviewer_once_settled(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- read research target/direction policy and pipeline existence from `state_root`
- validate canonical portfolio, selection, team board, and research evidence from `project_root`
- forward both roots through the Host automatic-close path
- add a distinct-root regression covering success, missing project portfolio, missing pipeline state, and same-root compatibility

## Validation
- `tests/skills/test_research_idea_portfolio.py`
- `tests/life/test_research_stage_auto_close.py` (21 focused tests passed)
- live harness-transfer distinct-root call returned `()`
- independent GPT-5.6 Sol review found no significant issue