### PR TITLE
fix(daemon): avoid false stalled mission failures

### DIFF
--- a/argus_skill/daemon/_life_worker_run.py
+++ b/argus_skill/daemon/_life_worker_run.py
@@ -42,6 +42,9 @@ class LifeWorkerRunMixin:
         from ..life.mission_outcome import mission_outcome_class
         from ..life.role_activity import role_activity
 
+        if self._supervisor_execution_active.is_set():
+            return []
+
         now = time.time()
         activities = role_activity(rf_state.runtime_root, now=now)
         if any(activity.active for activity in activities.values()):
@@ -266,6 +269,10 @@ class LifeWorkerRunMixin:
             )
             self._foreground_wait_guard.start()
 
+        # Protect a resumed running claim before the main loop reaches its first
+        # supervisor call. The loop clears this guard as soon as that call
+        # returns, which is the only point where executor-loss detection is safe.
+        self._supervisor_execution_active.set()
         self._start_running_stall_watcher(rf_state)
 
     def _rf_main_loop(self, rf_state: _RunForeverState) -> None:
@@ -276,6 +283,7 @@ class LifeWorkerRunMixin:
                 if self._deployment_handoff_gate():
                     break
                 summary: dict = {}
+                self._supervisor_execution_active.set()
                 try:
                     from ..manager._session_ops import manager_pipeline_yield_requested
 
@@ -358,6 +366,8 @@ class LifeWorkerRunMixin:
                         log.info("daemon: drain pass interrupted by stop request")
                         break
                     log.exception("daemon: drain pass raised; sleeping and retrying")
+                finally:
+                    self._supervisor_execution_active.clear()
                 log.info(
                     "daemon: drain pass stopped_by=%s suggested_sleep=%s",
                     summary.get("stopped_by") or "",

--- a/argus_skill/daemon/life_worker.py
+++ b/argus_skill/daemon/life_worker.py
@@ -230,6 +230,7 @@ class LifeWorker(LifeWorkerBootMixin, LifeWorkerRunMixin):
         self._control_started_at_iso = ""
         self._running_stall_stop = threading.Event()
         self._running_stall_thread: threading.Thread | None = None
+        self._supervisor_execution_active = threading.Event()
 
     # -- signal handling ------------------------------------------------
 

--- a/tests/daemon/test_life_worker.py
+++ b/tests/daemon/test_life_worker.py
@@ -938,6 +938,30 @@ def test_daemon_fails_running_item_after_roles_go_idle(
     assert events[0]["status"] == "failed"
 
 
+def test_daemon_does_not_fail_quiet_item_while_supervisor_is_running(
+    tmp_path: Path,
+) -> None:
+    memory = LifeMemory.open(tmp_path)
+    memory.init()
+    item = BacklogItem.new(title="quiet", objective="wait for external workers")
+    memory.backlog.add(item)
+    memory.backlog.mark_running(item.id)
+    memory.backlog.update(item.id, started_ts=time.time() - 31.0)
+    events: list[dict[str, Any]] = []
+    worker = LifeWorker(LifeWorkerConfig(life_dir=tmp_path, backend="memory"))
+    state = SimpleNamespace(
+        mem=memory,
+        runtime_root=tmp_path,
+        sink=SimpleNamespace(handle_event=events.append),
+    )
+    worker._supervisor_execution_active.set()
+
+    assert worker._fail_stalled_running_items(state) == []
+    stored = next(row for row in memory.backlog.active() if row.id == item.id)
+    assert stored.status == "running"
+    assert events == []
+
+
 def test_life_worker_continues_when_telegram_poller_start_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- track actual supervisor execution while checking stalled running items
- prevent quiet or parallel Team work from being failed while its executor is still alive
- retain orphan recovery after the supervisor returns

## Tests
- targeted daemon stalled-item and successive-mission tests
- Ruff on changed files