### PR TITLE
Reduce specialist review context without weakening integrated review

### DIFF
--- a/argus_skill/reviewer/_core.py
+++ b/argus_skill/reviewer/_core.py
@@ -196,6 +196,12 @@ def _parallel_final_review_passes(
             "locations. The integrated Reviewer separately checks scientific claims "
             "against source code and raw evidence; do not launch other reviewers."
         )
+    prompts = {
+        label: prompt
+        + "\n\nPut the complete assessment and all required repairs in your final response. "
+        "Intermediate progress messages are not forwarded to the integrated Reviewer."
+        for label, prompt in prompts.items()
+    }
     findings: dict[str, str] = {}
     if comparison is not None and identical_snapshot_pair(comparison):
         prompts.pop("ScientificLoss", None)
@@ -400,7 +406,7 @@ def _parallel_final_review_passes(
             **usage,
         )
     findings.update({
-        label: "\n".join(results[label].agent_messages or []).strip()
+        label: "\n".join((results[label].agent_messages or [])[-1:]).strip()
         for label in prompts
     })
     empty = next((label for label, text in findings.items() if not text), "")

--- a/argus_skill/roles/prompts/registry.py
+++ b/argus_skill/roles/prompts/registry.py
@@ -74,7 +74,13 @@ class RolePromptCatalog:
         from ...verticals._base import load_vertical_contract
 
         contract = load_vertical_contract(vertical, project_root=root)
-        vertical_banner = contract.banner(banner_role)
+        # Specialist assessments do not own the integrated Reviewer's writeback.
+        vertical_banner = (
+            ""
+            if request.role is RoleName.REVIEWER
+            and request.operation in {reviewer.COLD_READ, reviewer.SCIENCE_LOSS_CHECK}
+            else contract.banner(banner_role)
+        )
         domain = ""
         domain_banner = ""
         if root is not None and not str(request.vertical or "").strip():

--- a/docs/evaluations/reviewer-specialist-ab-2026-09-06.json
+++ b/docs/evaluations/reviewer-specialist-ab-2026-09-06.json
@@ -1,0 +1,218 @@
+[
+  {
+    "case": "cold-clear",
+    "operation": "cold_read",
+    "arm": "baseline",
+    "expected": "pass",
+    "assessment": {
+      "verdict": "pass",
+      "reason": "The fixture is internally consistent and preserves the central result: reducing median latency from 20 ms to 10 ms means half the latency and a 2x speedup. The controls and scope limitation support rather than contradict that conclusion."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 3278,
+    "usage": {
+      "input_tokens": 642,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 59,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 701
+    },
+    "seconds": 2.269
+  },
+  {
+    "case": "cold-clear",
+    "operation": "cold_read",
+    "arm": "candidate",
+    "expected": "pass",
+    "assessment": {
+      "verdict": "pass",
+      "reason": "The fixture is internally consistent: reducing median latency from 20 ms to 10 ms means the candidate takes half as long, equivalently a 2\u00d7 speedup. Page 2 supplies the essential controls and appropriately limits the claim to the microbenchmark, with no substantive contradiction or edit-induced loss."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 2590,
+    "usage": {
+      "input_tokens": 518,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 73,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 591
+    },
+    "seconds": 1.551
+  },
+  {
+    "case": "cold-contradiction",
+    "operation": "cold_read",
+    "arm": "candidate",
+    "expected": "fail",
+    "assessment": {
+      "verdict": "fail",
+      "reason": "Page 1's headline claim that the candidate is 2\u00d7 faster directly contradicts Table 1 on page 2, where both candidate and baseline have 20 ms latency for the same measurement, workload, and units. Smallest repair: correct either the headline claim or the table so the reported comparison is internally consistent."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 2455,
+    "usage": {
+      "input_tokens": 491,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 78,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 569
+    },
+    "seconds": 1.759
+  },
+  {
+    "case": "cold-contradiction",
+    "operation": "cold_read",
+    "arm": "baseline",
+    "expected": "fail",
+    "assessment": {
+      "verdict": "fail",
+      "reason": "The headline claim on page 1 directly contradicts Table 1 on page 2: identical 20 ms latencies do not support a 2\u00d7 speedup under the same measurement, workload, and units. Repair the headline to state equal latency, or correct Table 1 if one value is an edit error."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 3143,
+    "usage": {
+      "input_tokens": 615,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 77,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 692
+    },
+    "seconds": 1.628
+  },
+  {
+    "case": "loss-relocation",
+    "operation": "science_loss_check",
+    "arm": "baseline",
+    "expected": "pass",
+    "assessment": {
+      "verdict": "pass",
+      "reason": "No scientific semantic loss or contradiction. The workload A improvement remains in the main text, while the workload B adverse result is preserved with exact values and direction in Appendix Table 2 and is explicitly cross-referenced from the main text."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 2055,
+    "usage": {
+      "input_tokens": 404,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 59,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 463
+    },
+    "seconds": 1.753
+  },
+  {
+    "case": "loss-relocation",
+    "operation": "science_loss_check",
+    "arm": "candidate",
+    "expected": "pass",
+    "assessment": {
+      "verdict": "pass",
+      "reason": "No scientific meaning or coverage is lost. The workload A improvement remains in the main text, while the adverse workload B result is preserved through an explicit cross-reference to Appendix Table 2, which gives the exact baseline and candidate values (20 ms to 24 ms) and identifies the change as a slowdown."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 1367,
+    "usage": {
+      "input_tokens": 280,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 74,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 354
+    },
+    "seconds": 1.474
+  },
+  {
+    "case": "loss-omission",
+    "operation": "science_loss_check",
+    "arm": "candidate",
+    "expected": "fail",
+    "assessment": {
+      "verdict": "fail",
+      "reason": "The after snapshot omits the adverse workload B result: latency increased from 20 ms to 24 ms. This removes a material limitation and narrows the result matrix to only the favorable workload A outcome, with no remaining carrier for the missing slowdown."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 1303,
+    "usage": {
+      "input_tokens": 269,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 63,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 332
+    },
+    "seconds": 1.651
+  },
+  {
+    "case": "loss-omission",
+    "operation": "science_loss_check",
+    "arm": "baseline",
+    "expected": "fail",
+    "assessment": {
+      "verdict": "fail",
+      "reason": "The after snapshot omits the adverse workload B result: latency increased from 20 ms to 24 ms. This is an edit-induced loss of a material limitation and changes the reported result matrix by retaining only the favorable workload A outcome."
+    },
+    "passed": true,
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "low",
+    "prompt_chars": 1991,
+    "usage": {
+      "input_tokens": 393,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 60,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 453
+    },
+    "seconds": 1.694
+  }
+]

--- a/docs/evaluations/reviewer-specialist-ab-2026-09-06.md
+++ b/docs/evaluations/reviewer-specialist-ab-2026-09-06.md
@@ -1,0 +1,130 @@
+# Specialist review token-efficiency A/B
+
+Date: 2026-09-06. Baseline: upstream `0840b58e03d1`.
+Coordination: upstream issue #96.
+
+## Change and authority boundaries
+
+Two concrete issues remained after the existing token-accounting and
+unchanged-PDF reuse fixes:
+
+1. The prompt catalog prepended the integrated research Reviewer banner to
+   `cold_read` and `science_loss_check`. That banner asks the recipient to build
+   a contribution, repair the current stage, and overwrite `paper/REVIEW.md`.
+   These instructions conflict with the specialists' existing read-only,
+   PDF-only or immutable-snapshot assignments. The specialists now receive
+   their complete operation-specific policy without this generic banner.
+   The integrated Reviewer's banner, venue standard, and writeback authority
+   are unchanged.
+2. Specialist results concatenated every assistant message, including progress
+   reports and tentative findings, into the integrated Reviewer's evidence.
+   The host now requests a complete final assessment and forwards that final
+   message without truncating it. It does not promote earlier progress into
+   evidence when the final message is empty. Original provider logs and usage
+   accounting are unchanged.
+
+These changes do not remove a specialist pass, cache scientific judgments,
+relax the independent integrated review, change models or reasoning settings
+in production, or widen budgets or permissions. Existing PDF/model/policy
+invalidation continues to apply. No new cache, fingerprint, or retry mechanism
+was added.
+
+## Live prompt A/B
+
+The opt-in script `reviewer_specialist_ab.py` sends four public miniature
+fixtures to a Responses-compatible endpoint, once per arm, with no tools.
+Both arms receive the same operation policy and fixture instruction.
+The baseline recreates the catalog's old generic-banner-plus-operation
+composition; the candidate uses the changed catalog directly.
+
+The run requested `gpt-5.6-sol`, used low reasoning effort, and received
+`gpt-5.6-sol` in each response. The host's existing relay internally maps that
+requested model to `gpt-5.6-sol-fast`; this is a paired comparison on that
+route, not a claim of validation on every deployment of either model name.
+There were eight requests total, no retries, and no production configuration
+changes. Arm order alternates AB/BA. Every response reported zero cached input
+and zero reasoning tokens.
+
+| Fixture | Expected | Baseline input tokens | Candidate input tokens | Baseline / candidate result |
+|---|---|---:|---:|---|
+| Clear latency comparison with explicit scope | pass | 642 | 518 | pass / pass |
+| 2x speedup claim contradicted by equal latencies | fail | 615 | 491 | fail / fail |
+| Adverse result relocated with an explicit appendix reference | pass | 404 | 280 | pass / pass |
+| Adverse result omitted from the after snapshot | fail | 393 | 269 | fail / fail |
+| **Total** | **4/4 correct per arm** | **2,054** | **1,558** | **No fixture verdict regression** |
+
+Input tokens decreased **24.15%** on these fixtures. Output tokens increased
+from **255 to 288**, so total reported tokens decreased from **2,309 to 1,846**
+or **20.05%** in this run. The raw public-fixture assessments and per-request
+usage are in `reviewer-specialist-ab-2026-09-06.json`.
+
+These are narrow semantic acceptance fixtures, not full papers: the shared
+fixture instruction explicitly limits the judgment to contradictions and
+edit-induced loss. This tests prompt composition, not the additional final-
+assessment instruction in the complete host pass or a real PDF rendering/tool
+workflow. Four paired fixtures cannot establish general scientific-quality
+equivalence, total production savings, or a statistically stable output-token
+reduction. The production reasoning setting was not changed to the probe's
+low setting.
+
+### Reproduction
+
+From this checkout, using the existing Argus Python environment:
+
+```bash
+# Supply your authorized endpoint and key without committing the credential.
+PYTHONPATH=. python docs/evaluations/reviewer_specialist_ab.py \
+  --endpoint "$ARGUS_AB_RESPONSES_ENDPOINT" \
+  --model gpt-5.6-sol \
+  --output /tmp/reviewer-specialist-ab.json
+```
+
+The script requires `ARGUS_AB_API_KEY` in its environment. It reads no local
+manuscripts, account configuration, or runtime logs. Provider failures are
+surfaced, completed results are saved after each request, and a wrong expected
+verdict makes the run fail.
+
+## Historical handoff replay: a separate measurement
+
+A read-only local replay covered 74 completed, error-free isolated PDF-review
+sessions observed before 07:47 PDT on 2026-09-06. Their 215 nonempty assistant
+messages totalled 47,232 characters under the old newline-concatenation rule.
+Keeping each complete final message totalled 27,066 characters:
+**20,166 fewer characters, or 42.70%**.
+
+This is an aggregate character measurement of the specialist assessment field,
+not a tokenizer measurement or a second live experiment. It does not include
+the surrounding integrated-review prompt, measure upstream specialist-call
+savings, or prove every historical final answer was substantively complete.
+Raw trajectories, unpublished manuscripts, session identifiers, and account
+identities stay local and are not included in this report.
+
+The regression fixture explicitly includes a tentative missing-control concern
+followed by a final assessment that corrects it and retains a real page-2
+overlap finding and repair. Only the complete final evidence is forwarded and
+cached; the actual provider usage remains accounted for. Empty final messages
+remain failures rather than falling back to progress.
+
+## Focused regression evidence
+
+80 existing/extended tests passed across:
+
+- `tests/test_paper_pass_reuse.py`
+- `tests/skills/test_paper_narrative_packaging.py`
+- `tests/test_stop_kind_lifecycle.py`
+- `tests/skills/test_stage_checklists.py`
+- `tests/roles/test_prompt_catalog.py`
+
+This includes the real pass orchestration with test backends, immutable/PDF-only
+workspace boundaries, unchanged-PDF cache hits, changed PDF/policy/model
+invalidation, provider failures and stop signals, operation-specific prompt
+composition, and preservation of integrated review authority. Ruff passed for
+the changed Python files and opt-in A/B script.
+
+## Deployment and cooperation
+
+Development and comparisons used an isolated branch/worktree. Active research
+jobs and the shared runtime checkout were not edited or restarted. The patch
+is for upstream review before a coordinated deployment at a safe job boundary.
+An in-memory cache or already-running Python process is not claimed to have
+adopted the new code merely because the branch was pushed.

--- a/docs/evaluations/reviewer_specialist_ab.py
+++ b/docs/evaluations/reviewer_specialist_ab.py
@@ -1,0 +1,126 @@
+"""Opt-in, tool-free live comparison of integrated versus specialist-only prompts.
+
+Run from the checkout with ARGUS_AB_API_KEY set. This sends only the four public
+fixtures below; it does not read manuscripts, change runtime settings, or start
+an Argus mission. The Responses-compatible endpoint is supplied explicitly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+from argus_skill.roles.prompts import ChecklistMode, resolve_role_prompt
+from argus_skill.roles.prompts.reviewer import (
+    COLD_READ,
+    SCIENCE_LOSS_CHECK,
+    evaluate_request,
+)
+from argus_skill.verticals._base import load_vertical_contract
+
+CASES = (
+    (
+        "cold-clear", COLD_READ, "pass",
+        "PDF page 1: A controlled microbenchmark measures the same CPU operation. "
+        "Baseline median latency is 20 ms; candidate median latency is 10 ms, "
+        "so the candidate takes half as long (2x speedup). Page 2: Both methods "
+        "use the same inputs, CPU, thread count, and 100 trials. The conclusion "
+        "is limited to this microbenchmark, not end-to-end application speed.",
+    ),
+    (
+        "cold-contradiction", COLD_READ, "fail",
+        "PDF page 1: Our candidate is 2x faster than the baseline. Page 2, Table 1: "
+        "Baseline latency 20 ms; candidate latency 20 ms. These are the exact "
+        "same measurement, workload, and units; no alternative timing is reported.",
+    ),
+    (
+        "loss-relocation", SCIENCE_LOSS_CHECK, "pass",
+        "Before: The candidate reduces latency from 20 ms to 10 ms on workload A; "
+        "on workload B it increases latency from 20 ms to 24 ms. "
+        "After: Main text reports the workload A improvement and explicitly refers "
+        "to Appendix Table 2 for workload B. Appendix Table 2 states baseline "
+        "20 ms, candidate 24 ms, and explicitly describes the slowdown on B.",
+    ),
+    (
+        "loss-omission", SCIENCE_LOSS_CHECK, "fail",
+        "Before: The candidate reduces latency from 20 ms to 10 ms on workload A; "
+        "on workload B it increases latency from 20 ms to 24 ms. "
+        "After: The candidate reduces latency from 20 ms to 10 ms on workload A. "
+        "This is the entire after snapshot: workload B and its slowdown are absent.",
+    ),
+)
+
+FIXTURE_RULE = (
+    "\n\nControlled acceptance fixture: the complete relevant PDF text or before/after "
+    "extract follows. Judge only whether it contains a substantive contradiction "
+    "or an edit-induced loss; do not demand the rest of a full paper for this "
+    "miniature fixture. No tools or other files are available. Do not edit files. "
+    'Return only JSON: {"verdict":"pass" or "fail","reason":"concrete explanation"}.'
+    "\n\n"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True, help="Full /v1/responses URL")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    token = os.environ["ARGUS_AB_API_KEY"]
+    results: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix="argus-specialist-ab-") as root:
+        contract = load_vertical_contract("research", project_root=Path(root))
+        for index, (name, operation, expected, fixture) in enumerate(CASES):
+            fragment = contract.prompt_fragment(
+                role="reviewer", operation=operation, stage="review",
+                scope="", project_root=Path(root),
+            )
+            prompts = {
+                "baseline": contract.banner("reviewer").strip() + "\n\n" + fragment.strip(),
+                "candidate": resolve_role_prompt(evaluate_request(
+                    root, vertical="research", stage="review",
+                    checklist_mode=ChecklistMode.NONE, operation=operation,
+                )).role_banner,
+            }
+            for arm in (("baseline", "candidate") if index % 2 == 0 else ("candidate", "baseline")):
+                prompt = prompts[arm] + FIXTURE_RULE + fixture
+                request = urllib.request.Request(
+                    args.endpoint,
+                    data=json.dumps({
+                        "model": args.model, "input": prompt, "stream": False,
+                        "reasoning": {"effort": "low"}, "max_output_tokens": 2048,
+                    }).encode(),
+                    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                )
+                started = time.monotonic()
+                with urllib.request.urlopen(request, timeout=120) as response:
+                    body = json.load(response)
+                if body.get("status") != "completed":
+                    raise RuntimeError(f"{name}/{arm}: response did not complete")
+                text = "".join(
+                    item["text"]
+                    for message in body["output"]
+                    for item in message.get("content", [])
+                    if item.get("type") == "output_text"
+                )
+                assessment = json.loads(text)
+                results.append({
+                    "case": name, "operation": operation, "arm": arm,
+                    "expected": expected, "assessment": assessment,
+                    "passed": assessment.get("verdict") == expected,
+                    "model": body.get("model"), "reasoning_effort": "low",
+                    "prompt_chars": len(prompt), "usage": body["usage"],
+                    "seconds": round(time.monotonic() - started, 3),
+                })
+                args.output.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+                print(json.dumps({key: results[-1][key] for key in ("case", "arm", "passed", "usage")}), flush=True)
+    if not all(row["passed"] for row in results):
+        raise SystemExit("At least one acceptance fixture failed; see the saved results.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_paper_narrative_packaging.py
+++ b/tests/skills/test_paper_narrative_packaging.py
@@ -15,7 +15,11 @@ from argus_skill.core.pipeline_state import read_pipeline_state, write_pipeline_
 from argus_skill.reviewer._core import ReviewerConfig, _parallel_final_review_passes
 from argus_skill.roles.prompts import ChecklistMode, resolve_role_prompt
 from argus_skill.roles.prompts.engineer import NARRATIVE_EDIT, mission_request
-from argus_skill.roles.prompts.reviewer import COLD_READ, evaluate_request
+from argus_skill.roles.prompts.reviewer import (
+    COLD_READ,
+    SCIENCE_LOSS_CHECK,
+    evaluate_request,
+)
 from argus_skill.skills.vertical_select import persist_vertical
 from argus_skill.verticals._base import load_vertical_contract
 from argus_skill.verticals.research.academic_language_review import (
@@ -202,6 +206,30 @@ def test_prompt_catalog_accepts_research_operations(tmp_path: Path) -> None:
     assert "cold_read" in cold.fragment_ids[-1]
 
     contract = load_vertical_contract("research", project_root=tmp_path)
+    science = resolve_role_prompt(
+        evaluate_request(
+            tmp_path, vertical="research", stage="review",
+            checklist_mode=ChecklistMode.NONE, operation=SCIENCE_LOSS_CHECK,
+        )
+    )
+    integrated = resolve_role_prompt(
+        evaluate_request(
+            tmp_path, vertical="research", stage="review",
+            checklist_mode=ChecklistMode.NONE,
+        )
+    )
+    assert cold.role_banner == render_role_prompt_fragment(
+        role="reviewer", operation=COLD_READ, stage="review", scope="",
+        project_root=tmp_path,
+    )
+    assert science.role_banner == render_role_prompt_fragment(
+        role="reviewer", operation=SCIENCE_LOSS_CHECK, stage="review", scope="",
+        project_root=tmp_path,
+    )
+    assert "overwrite paper/REVIEW.md" not in cold.role_banner
+    assert "overwrite paper/REVIEW.md" not in science.role_banner
+    assert contract.banner("reviewer") in integrated.role_banner
+    assert "overwrite paper/REVIEW.md" in integrated.role_banner
     assert contract.engineer_operation("paper") == "author_draft"
     assert contract.engineer_operation("review") == "narrative_edit"
 

--- a/tests/test_paper_pass_reuse.py
+++ b/tests/test_paper_pass_reuse.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from argus_skill.core.manuscript_narrative_runtime import prepare_narrative_snapshot
+from argus_skill.core.models import RunnerResult
 from argus_skill.core.pipeline_state import read_pipeline_state, write_pipeline_state
 from argus_skill.reviewer._core import ReviewerConfig, _parallel_final_review_passes
 from argus_skill.skills.vertical_select import persist_vertical
@@ -71,6 +72,61 @@ def test_unchanged_paper_skips_loss_and_reuses_pdf_assessments(paper_review):
     assert second.status == "continue"  # Cached passes never certify the mission.
     assert "reviewer-visual: pass" in second.reason
     assert "reviewer-coldread: pass" in second.reason
+
+
+def test_only_complete_final_assessments_are_forwarded_and_cached(paper_review, monkeypatch):
+    _, config = paper_review
+    from argus_skill.reviewer import _core
+
+    calls = []
+
+    def assess(_runner, **kwargs):
+        assert "complete assessment and all required repairs in your final response" in kwargs["prompt"]
+        label = kwargs["run_label"]
+        calls.append(label)
+        return RunnerResult(
+            exit_code=0,
+            agent_messages=[
+                "I will inspect the PDF.",
+                "Tentative concern: the control might be missing.",
+                f"{label}: fail. Page 2: labels overlap; separate them. "
+                "The control is present in Table 1.",
+            ],
+            input_tokens=30,
+            output_tokens=12,
+        )
+
+    monkeypatch.setattr(_core, "gateway_run_exec", assess)
+    first = _parallel_final_review_passes(PaperRunner(), config)
+    assert len(calls) == 2
+    for label in calls:
+        assert f"{label}: fail. Page 2: labels overlap; separate them." in first.reason
+    assert first.reason.count("The control is present in Table 1.") == 2
+    assert "I will inspect" not in first.reason
+    assert "Tentative concern" not in first.reason
+    assert (first.input_tokens, first.output_tokens) == (60, 24)
+    assert first.status == "continue"
+
+    cached = _parallel_final_review_passes(PaperRunner(), config)
+    assert len(calls) == 2
+    assert cached.reason == first.reason
+    assert cached.input_tokens == cached.output_tokens == 0
+
+
+def test_empty_final_assessment_does_not_promote_progress_to_evidence(paper_review, monkeypatch):
+    _, config = paper_review
+    from argus_skill.reviewer import _core
+
+    monkeypatch.setattr(
+        _core, "gateway_run_exec",
+        lambda *_args, **_kwargs: RunnerResult(
+            exit_code=0, agent_messages=["I will inspect the PDF.", "   "],
+        ),
+    )
+    result = _parallel_final_review_passes(PaperRunner(), config)
+    assert result.backend_unavailable
+    assert "returned no assessment" in result.reason
+    assert not config.paper_pass_cache
 
 
 def test_source_change_is_reviewed_even_when_rendered_bytes_match(paper_review):


### PR DESCRIPTION
## Change

Progress on #96, based on freshly fetched upstream `0840b58e03d1`.

- Keep the complete cold-read / semantic-loss policy, but omit integrated Reviewer authoring and REVIEW.md-writeback instructions from these read-only specialist operations.
- Ask for a complete final assessment and forward that instead of intermediate progress; preserve failures, accounting, cache invalidation, and integrated Reviewer authority.
- Include a runnable opt-in live A/B script, public-fixture responses, and a report with explicit limitations.

## Measured comparison

Four paired, tool-free public semantic fixtures on the existing Responses route, requested/reported model `gpt-5.6-sol` (host relay maps it to `gpt-5.6-sol-fast`), low reasoning:

| Metric | Baseline | Candidate |
|---|---:|---:|
| Correct fixture verdicts | 4/4 | 4/4 |
| Input tokens | 2,054 | 1,558 |
| Output tokens | 255 | 288 |
| Total tokens | 2,309 | 1,846 |

Input reduction: **24.15%**. Observed total-token reduction: **20.05%**. A separate local historical handoff replay shrank the assessment text by **42.70% in characters**, not measured tokens.

These are scoped initial results, not a production cost-saving percentage or proof of full-paper quality equivalence. The live experiment tests prompt composition, not a real PDF/tool workflow. No private manuscripts, logs, or account identities are published.

## Coverage and rollout

80 focused tests passed, plus changed-file Ruff. The complete report is `docs/evaluations/reviewer-specialist-ab-2026-09-06.md`.

Active jobs and the shared runtime were not changed or restarted. Coordinate deployment at a safe job boundary; existing processes have not automatically adopted this branch.