### PR TITLE
Repair current-main CI without weakening review or visualization contracts

### DIFF
--- a/argus_skill/core/vertical_contract.py
+++ b/argus_skill/core/vertical_contract.py
@@ -164,6 +164,7 @@ class VerticalContract:
     ground_before_handoff: bool = False
     role_guidance: Callable[[str], str] | None = None
     role_prompt_fragment: RolePromptFragment | None = None
+    role_prompt_context: RolePromptFragment | None = None
     evidence_schema: Any = None
     requires_independent_review: bool = False
     completion_contract_version: int = 0
@@ -570,6 +571,11 @@ def vertical_contract(name: str, provider: Any) -> VerticalContract:
         for source, target in aliases.items()
         if str(source).strip() and str(target).strip()
     } if isinstance(aliases, dict) else {}
+    role_prompt_context = getattr(provider, "render_role_prompt_context", None)
+    if role_prompt_context is not None and not callable(role_prompt_context):
+        raise VerticalContractError(
+            f"vertical {name!r} has a non-callable role prompt context"
+        )
     stage_completion_validator = getattr(provider, "stage_completion_issues", None)
     if stage_completion_validator is not None and not callable(stage_completion_validator):
         raise VerticalContractError(
@@ -705,6 +711,7 @@ def vertical_contract(name: str, provider: Any) -> VerticalContract:
             if callable(getattr(provider, "render_role_prompt_fragment", None))
             else None
         ),
+        role_prompt_context=role_prompt_context,
         evidence_schema=getattr(provider, "EVIDENCE_SCHEMA", None),
         requires_independent_review=bool(
             getattr(provider, "REQUIRE_INDEPENDENT_REVIEW", True)

--- a/argus_skill/roles/prompts/planner.py
+++ b/argus_skill/roles/prompts/planner.py
@@ -42,23 +42,17 @@ _BOUNDED_DAG_FOOTER = decision_footer_instruction(
     "TASK_OBJECTIVE=design and run the experiment whose outcome most changes what we believe, with success and failure criteria stated in advance"
 )
 
-_PLAN_UPDATE_INSTRUCTION = """
-The footer may end with `PLAN_UPDATE=` and the full Markdown for RESEARCH_PLAN.md,
-after all task and retirement lines.
-"""
-
 _PLANNER_CORE_CONTRACT = """
 ## Planner read-only delegation contract
 Read state and delegate implementation to Engineer.
 Do not edit project files; Engineer owns edits, commands, tests, iteration.
 
-- Reuse Manager/completed decisions; give Engineer one task with its decision,
-  inputs, and check. Split only for dependencies/parallel work.
+- Reuse Manager/completed decisions in Engineer's task, inputs, and check;
+  split only for dependencies/parallel work.
 - Cited `life.planner.error`/`life.manager.intent.failed`, review-churn receipts, or
-  corrective OperatorContext may yield `TASK_VERTICAL=argus_maintenance`. Require
-  a harness hypothesis, executable acceptance, non-goals, isolated Engineer→Reviewer,
-  no counters/detectors/audits/make-work, and Reviewer `done` plus operator approval
-  before deployment.
+  corrective OperatorContext justify `TASK_VERTICAL=argus_maintenance` with a
+  harness hypothesis, executable acceptance, non-goals, and isolated Engineer→Reviewer.
+  No counters/detectors/audits/make-work; deployment needs Reviewer `done` and operator approval.
 - Follow the operator's requested actions and order. Existing artifacts or a usable
   alternative do not replace the first unmet requested action. Do not invent
   cleanup/docs/rechecks.
@@ -68,50 +62,47 @@ Do not edit project files; Engineer owns edits, commands, tests, iteration.
   when decision-relevant. When related attempts repeatedly fail, revisit primary papers
   and official implementations. Performance claims need code-path evidence and
   timing/profiling or a controlled comparison.
-- Set `project_done=true` only when the operator goal is complete. For a direct
-  task the Reviewer `done` closes it; review again only if requested or the verdict finds a gap.
+- Set `project_done=true` only for a complete operator goal. Reviewer `done`
+  closes direct tasks; review again only on request or a verdict gap.
   Integrity and reproducibility are admission constraints, not a routing command.
-  Never emit a bare launch verdict; say what happened and the next action or Host rejects it.
-- End with `PROJECT_DONE`/`REASON`; each task needs `TASK_TITLE`/`TASK_OBJECTIVE`.
-  `ADVANCE_TO_STAGE` is optional (omit to hold) and Host-valid; `TASK_SCOPE` is
+  Host rejects bare launch verdicts: say what happened and the next action.
+- Footer: `PROJECT_DONE`/`REASON`; tasks need `TASK_TITLE`/`TASK_OBJECTIVE`.
+  `ADVANCE_TO_STAGE` must be Host-valid and is optional (omit to hold); `TASK_SCOPE` is
   optional (default `bounded`). Other fields: `TASK_KEY`/`TASK_DEPS`, `TASK_HYPOTHESIS`,
   `TASK_GOAL_CONTRIBUTION`, `TASK_EXPECTED_REGRESSIONS`, `TASK_DECISION_RULE`,
   `TASK_ACCEPTANCE_CHECK`, `TASK_PARALLEL_SAFE`, `TASK_OWNS_PATHS`, and
   `TASK_VERTICAL`.
-- Optional `RETIRE_TASK=<item id> | <one-sentence reason>`: one line per item;
-  reason required. When the evidence has refuted a hypothesis or closed a line of work,
-  retire its pending tasks with RETIRE_TASK so they are not executed later under another title;
+- `RETIRE_TASK=<item id> | <one-sentence reason>` retires pending work whose
+  hypothesis is refuted or line closed; one line per item, reason required.
+  Do not relaunch it under another title;
   running work and done work cannot be retired.
 - External waits: `blocker_fingerprint`, `recheck_condition`, `recheck_token`, semantically
   `wake_on` (synonyms/combined sources), and `watched_paths`; `operator_action_required`
   is operator-only. Host chooses an event or a timed recheck.
-- In-flight background work launched by Argus is a valid external wait. When pending
-  tasks depend on running/paused_external_work missions and nothing can start,
-  return `PROJECT_DONE=false`, `WAITING=true`, `REASON` and no `TASK_*` blocks.
+- In-flight background work launched by Argus is a valid external wait.
+  If only running/paused_external_work can unblock tasks, keep `PROJECT_DONE` false;
+  return `WAITING=true`, `REASON` and no `TASK_*` blocks.
   Use `WAIT_MODE=event`, `WAKE_ON=subagent_state`, `WAIT_ID=<live subagent id>`,
   `BLOCKER_FINGERPRINT=<live subagent id>`, `RECHECK_TOKEN=<run id>`, and
   `RECHECK_CONDITION=<which in-flight work must finish>`. Keep the token stable
-  while that run is unchanged. This is an accepted, productive waiting verdict;
-  do not invent dependent tasks to make a waiting cycle look executable. Schedule
-  independent work only when it can actually run without the awaited results.
-- REASON and PLAN_REASON are operator-facing: one clear sentence in the operator's
-  language stating the decision and next action. Do not emit
-  field names or status tokens in their values.
-""" + _PLANNER_DECISION_FOOTER + _PLAN_UPDATE_INSTRUCTION
+  for the same run. Do not invent dependent tasks; schedule only genuinely independent work.
+- REASON/PLAN_REASON: one operator-language sentence with decision and next action,
+  not field/status tokens.
+""" + _PLANNER_DECISION_FOOTER
 
 _RESEARCH_PLAN_CONTRACT = """## Research plan (living document)
-Planner owns `RESEARCH_PLAN.md` in daemon state. Create absent/invalid plans from
-Manager brief/OBJECTIVE.md and journal. Update on hypothesis status, experiment
-outcomes, or direction changes. Optional final `PLAN_UPDATE` replaces it in full;
-omit to keep it.
+Own daemon-state `RESEARCH_PLAN.md`. Create missing/invalid plans from
+Manager brief/OBJECTIVE.md and journal; revise on hypothesis, result, or direction
+changes. `PLAN_UPDATE=` ends the footer with full Markdown after tasks/retirements;
+omit to keep the document.
 
-Under ~300 lines, ordered: `# Research plan` and objective one-liner;
-`## Central hypotheses` (numbered, untested/supported/refuted/abandoned, with
-one-line evidence pointers); `## Experiment program` (next experiments and why
-each is highest-information, without fixed numeric pass/fail thresholds); `## Established results`
-(evidence refs); `## Dead ends` (attempts and why abandoned); `## Next milestone`
-(scientifically valuable improvement supporting a scoped paper). Never delete
-Dead ends entries; prune repetition if the projection reports truncation.
+Under ~300 lines, ordered: `# Research plan` + objective;
+`## Central hypotheses` (numbered untested/supported/refuted/abandoned + evidence);
+`## Experiment program` (next experiments + information value,
+without fixed numeric pass/fail thresholds); `## Established results` (evidence refs);
+`## Dead ends` (attempts + abandonment reasons); `## Next milestone`
+(scientifically valuable improvement for a scoped paper). Never delete Dead ends;
+prune repetition on truncation.
 
 Current document:
 """
@@ -446,10 +437,6 @@ def build_continuous_prompt(
         )
     )
     if prompt_context.vertical == "research":
-        planner_core_contract = planner_core_contract.replace(
-            _PLAN_UPDATE_INSTRUCTION,
-            "",
-        )
         research_plan_context = ""
 
     research_target_block = ""
@@ -689,9 +676,6 @@ def build_continuous_prompt(
         ),
         planner_hygiene_block,
         cycle_line,
-        "Use only the focused read/search budget above, delegate the next concrete "
-        "work or report a real "
-        "blocker, then end with the Planner decision footer.",
         trailing_policy,
         operator_context,
     )

--- a/argus_skill/roles/prompts/planner.py
+++ b/argus_skill/roles/prompts/planner.py
@@ -86,8 +86,8 @@ Do not edit project files; Engineer owns edits, commands, tests, iteration.
   `BLOCKER_FINGERPRINT=<live subagent id>`, `RECHECK_TOKEN=<run id>`, and
   `RECHECK_CONDITION=<which in-flight work must finish>`. Keep the token stable
   for the same run. Do not invent dependent tasks; schedule only genuinely independent work.
-- REASON/PLAN_REASON: one operator-language sentence with decision and next action,
-  not field/status tokens.
+- REASON and PLAN_REASON are operator-facing: one operator-language sentence with
+  decision and next action. Do not emit field names or status tokens in their values.
 """ + _PLANNER_DECISION_FOOTER
 
 _RESEARCH_PLAN_CONTRACT = """## Research plan (living document)
@@ -98,9 +98,9 @@ omit to keep the document.
 
 Under ~300 lines, ordered: `# Research plan` + objective;
 `## Central hypotheses` (numbered untested/supported/refuted/abandoned + evidence);
-`## Experiment program` (next experiments + information value,
-without fixed numeric pass/fail thresholds); `## Established results` (evidence refs);
-`## Dead ends` (attempts + abandonment reasons); `## Next milestone`
+`## Experiment program` (information-ranked experiments,
+without fixed numeric pass/fail thresholds); `## Established results` (refs);
+`## Dead ends` (attempts + why abandoned); `## Next milestone`
 (scientifically valuable improvement for a scoped paper). Never delete Dead ends;
 prune repetition on truncation.
 

--- a/argus_skill/roles/prompts/reviewer.py
+++ b/argus_skill/roles/prompts/reviewer.py
@@ -365,12 +365,22 @@ def render_reviewer_prompt(
             matched_review_skill_block = review_libraries.block + "\n\n"
     stage = prompt_context.stage
     research_context_block = ""
-    if prompt_context.vertical == "research" and operation == EVALUATE:
-        from ...verticals.research.prompt_policy import active_research_context
+    if prompt_context.vertical and operation == EVALUATE:
+        from ...verticals._base import load_vertical_contract
 
-        research_context_block = active_research_context(
-            stage, resolve_project_root(working_dir) if working_dir else _proot
-        )
+        context_provider = load_vertical_contract(
+            prompt_context.vertical, project_root=_proot
+        ).role_prompt_context
+        if context_provider is not None:
+            research_context_block = context_provider(
+                role="reviewer",
+                operation=operation,
+                stage=stage,
+                scope=scope_normalized,
+                project_root=(
+                    resolve_project_root(working_dir) if working_dir else _proot
+                ),
+            )
     direct_workflow = resolve_workflow_mode(_proot) == "direct"
     _measured = not _requires_engineering_audit and os.environ.get(
         "ARGUS_SKILL_MEASURED_MODE", ""

--- a/argus_skill/verticals/research/prompt_policy.py
+++ b/argus_skill/verticals/research/prompt_policy.py
@@ -583,6 +583,20 @@ def _reviewer_fragment(
     )
 
 
+def render_role_prompt_context(
+    *,
+    role: str,
+    operation: str,
+    stage: str,
+    scope: str,
+    project_root: Path | None,
+) -> str:
+    """Keep changing research evidence in the round delta, not the static policy."""
+    if role == "reviewer" and operation == "evaluate":
+        return active_research_context(stage, project_root)
+    return ""
+
+
 def render_role_prompt_fragment(
     *,
     role: str,
@@ -632,5 +646,6 @@ __all__ = [
     "local_hardware_block",
     "local_model_inventory_block",
     "render_role_prompt_fragment",
+    "render_role_prompt_context",
     "STAGE_PLAYBOOK_PATHS",
 ]

--- a/argus_skill/verticals/research/stages.py
+++ b/argus_skill/verticals/research/stages.py
@@ -15,7 +15,7 @@ from typing import Any
 from ...core.vertical_contract import IterationAssessment
 from ...skills.stage_machine import ChecklistItem
 from . import library_preparation
-from .prompt_policy import render_role_prompt_fragment
+from .prompt_policy import render_role_prompt_context, render_role_prompt_fragment
 from .review_purchase import review_purchase_policy
 
 log = logging.getLogger(__name__)
@@ -639,6 +639,7 @@ __all__ = [
     "import_legacy_state",
     "search_altitude_context",
     "render_role_prompt_fragment",
+    "render_role_prompt_context",
     "review_purchase_policy",
     "stage_completion_issues",
     "iteration_assessment",

--- a/frontend/core/src/eventRender/index.ts
+++ b/frontend/core/src/eventRender/index.ts
@@ -317,6 +317,7 @@ export function renderEvent(event: TypedArgusEvent, context: RenderContext): Ren
     case 'life.mission.skipped': case 'life.mission.orphaned': case 'life.mission.requeued':
     case 'life.manager.plan_challenge.decided': case 'life.vertical.resolved':
     case 'life.manager.backend_resolved': case 'life.planner.backend_resolved':
+    case 'life.planner.dependency_dropped':
     case 'life.engineer.backend_resolved': case 'life.reviewer.backend_resolved': case 'life.curator.backend_resolved':
     case 'life.runtime_failure.circuit_opened': case 'life.runtime_failure.circuit_blocked': case 'life.runtime_failure.canary_passed':
     case 'life.plan.revision.proposed': case 'life.plan.revision.rejected': case 'life.plan.revision.committed': case 'life.plan.node.superseded':

--- a/tests/core/test_vertical_contract.py
+++ b/tests/core/test_vertical_contract.py
@@ -32,6 +32,7 @@ def test_minimal_non_research_vertical_implements_only_documented_contract() -> 
     assert contract.mission_kind == "custom"
     assert contract.ground_before_handoff is False
     assert contract.banner("engineer") == ""
+    assert contract.role_prompt_context is None
     assert contract.evidence_schema is None
     assert contract.review_purchase(
         project_root=Path("."),
@@ -122,6 +123,19 @@ def test_non_callable_completion_validator_fails_visibly() -> None:
                 CHECKLIST_ITEMS={"verify": (_item("verify.output"),)},
                 completion_gate="none",
                 stage_completion_issues=[],
+            ),
+        )
+
+
+def test_non_callable_role_prompt_context_fails_visibly() -> None:
+    with pytest.raises(VerticalContractError, match="non-callable role prompt context"):
+        vertical_contract(
+            "broken",
+            SimpleNamespace(
+                CHECKLIST_STAGE_ORDER=("verify",),
+                CHECKLIST_ITEMS={"verify": (_item("verify.output"),)},
+                completion_gate="none",
+                render_role_prompt_context=[],
             ),
         )
 

--- a/tests/skills/test_paper_chart_style.py
+++ b/tests/skills/test_paper_chart_style.py
@@ -144,8 +144,11 @@ def test_research_data_figures_have_one_renderer_path() -> None:
     assert "single SciencePlots/Matplotlib data-figure path" in normalized_analysis
     assert "Any paper data/metric/result chart" in normalized_router
     assert (
-        "Conceptual, method, architecture, or teaser figure | "
+        "Other conceptual or teaser figure | "
         "Paper Framework Figure Studio"
+    ) in normalized_router
+    assert (
+        "Method pipeline or architecture overview | Research SVG Pipeline"
     ) in normalized_router
 
 


### PR DESCRIPTION
## Scope

Supporting repair while processing the open PR backlog, as authorized by the maintainer. This branch preserves the concurrently merged main changes through b55c10ac0.

- Route mutable Reviewer context through an optional, validated vertical-contract hook instead of importing a concrete research module from framework roles.
- Preserve both current manuscript evidence and the newly added live resource/model context in the per-round delta, outside the static session-reuse policy.
- Update the stale chart-route assertion to require the existing SVG pipeline for methods/architecture and Figure Studio for other conceptual/teaser figures.
- Include the already declared dependency-dropped event in the shared renderer fallback switch, preserving its existing runtime fallback behavior while restoring exhaustiveness/typechecking.

## Evidence

The original named-vertical architecture failures, stale chart assertion, and frontend type error were reproduced on current main before repair. After reconciliation with newer main: 98 targeted Python tests passed; web typecheck and all 33 event-renderer tests passed; changed-file Ruff and diff checks passed. No tests were disabled and no provider or budget protections were relaxed.

No active daemon, project workdir, credentials, or deployed checkout was modified. This PR is independent of the larger feature/Windows integration work still being reviewed.