### PR TITLE
Require Planner scale assessment before research paper handoff

### DIFF
--- a/argus_skill/manager/_stage_ops.py
+++ b/argus_skill/manager/_stage_ops.py
@@ -963,6 +963,35 @@ class _StageDecisionMixin:
                     ),
                 )
 
+        if cur == "experiment":
+            from ..skills.vertical_select import resolve_vertical, resolve_workflow_mode
+
+            if (
+                resolve_vertical(root) == "research"
+                and resolve_workflow_mode(root) == "staged"
+                and (
+                    open_ended
+                    or bool(continuous_objective.strip())
+                    or planner_verdict is not None
+                )
+                and (
+                    getattr(review, "status", "") != "done"
+                    or getattr(planner_verdict, "advance_to_stage", "") != "paper"
+                )
+            ):
+                return StageTransition(
+                    "hold",
+                    cur,
+                    "Keep Experiment open for Planner's post-result scale assessment. "
+                    "After Reviewer accepts the current experiment, Planner must "
+                    "compare its training and evaluation coverage with the operator "
+                    "objective, expand under the benchmark policy if insufficient, or "
+                    "request ADVANCE_TO_STAGE=paper with the adequacy rationale.",
+                    current_stage=cur,
+                    source="planner_scale_assessment_hold",
+                    diagnostic="experiment_scale_assessment_required",
+                )
+
         manuscript_binding = getattr(review, "manuscript_snapshot", None)
         if isinstance(manuscript_binding, dict):
             try:

--- a/argus_skill/verticals/research/prompt_policy.py
+++ b/argus_skill/verticals/research/prompt_policy.py
@@ -425,7 +425,15 @@ def paper_writing_standard() -> str:
     return (
         "The standard is a strong accepted paper at the selected venue, the kind the "
         "exemplar skill has you read; there is no house quota for sentences, words, "
-        "numbers, or caption format. Let the claim decide the form. The abstract is as "
+        "numbers, or caption format. Let the claim decide the form. "
+        "Apply 'Plan the manuscript length' in research-paper-playbook.md: "
+        "for a full-length paper, target nearly all permitted body space under "
+        "the exact track's official counting rules, not total PDF pages. "
+        "Respect explicit short-paper and partial-edit requests. Actively develop "
+        "principle-level analysis toward that target: mechanisms, assumptions, "
+        "derivations, and design tradeoffs. Experiments support the argument; do not write "
+        "an experiment report. Record the target and actual body extent "
+        "in existing research notes. The abstract is as "
         "long and as numerical as the venue's norm and the claim require: a large "
         "speedup is stated as a speedup, a narrow margin is stated with its "
         "uncertainty, and a mechanism finding may need no number at all. In prose, "
@@ -461,7 +469,15 @@ def paper_reviewer_standard() -> str:
         "prose recites a result matrix instead of arguing, when hedging or limitation "
         "lists stand in for a clear statement, or when internal workflow vocabulary "
         "appears. Do not ask for more hedging than the evidence requires, and do not "
-        "ask for a number where a plain statement is clearer."
+        "ask for a number where a plain statement is clearer. "
+        "Apply the manuscript-length policy in research-paper-playbook.md: "
+        "compare counted body extent with the full-paper writing target, "
+        "not total PDF pages. Judge the depth of principle-level analysis and "
+        "request expansion of terse mechanisms, derivations, and design tradeoffs. "
+        "Experiments should support the argument, "
+        "not turn it into an experiment report. Put actionable expansion requests "
+        "in the existing paper/REVIEW.md, "
+        "respecting explicit short-paper and partial-edit requests."
     )
 
 
@@ -487,6 +503,27 @@ def _planner_fragment(stage: str, project_root: Path | None) -> str:
             _stage_playbook_block(stage),
             active_research_context(stage, project_root),
             _hardware_block_for_stage(stage, project_root),
+            (
+                "## Post-result experiment scale assessment\n"
+                "After Reviewer accepts the current experiment, apply the "
+                "'Planner scale assessment after a passing experiment' section of "
+                "research-experiment-playbook.md before leaving Experiment. "
+                "Assess actual training and evaluation coverage against the operator "
+                "objective, not just the run's acceptance checks. If insufficient, "
+                "keep the stage and assign an incremental scale-up, preferring "
+                "existing benchmarks and reusing valid code, configurations, and results. "
+                "Apply the playbook's cost-aware benchmark policy: small custom "
+                "benchmarks are allowed with no API calls or only a small amount "
+                "within the authorized budget; reassess total cost when expanding. "
+                "Respect stricter project-specific restrictions. "
+                "If sufficient, explain why in the existing plan and REASON, "
+                "then return ADVANCE_TO_STAGE=paper with the paper task. "
+                "Do not schedule a separate inspection mission or repeat an "
+                "unchanged assessment; perform this judgment in your normal "
+                "planning turn."
+                if stage == "experiment"
+                else ""
+            ),
             (
                 "## Planner responsibility\n"
                 f"Plan only the highest-value unresolved work in `{stage or '(unknown)'}` "

--- a/argus_skill/verticals/research/skills/engineer/references/paper-writing-craft.md
+++ b/argus_skill/verticals/research/skills/engineer/references/paper-writing-craft.md
@@ -171,7 +171,11 @@ setting. Future work and caveats are optional, not a closing ritual.
 ## 10. Compress after expanding
 
 The first complete draft should be comprehensive. The final pass then removes
-what does not serve an explicit claim; a cut of a third is normal. In order:
+what does not serve an explicit claim, without a target reduction fraction.
+Apply the manuscript-length target in `research-paper-playbook.md` for the
+selected submission type, focusing expansion on principle-level analysis:
+the mechanism, derivations, and design tradeoffs. When compression is needed,
+remove in order:
 repeated motivation, tutorial background the venue's reviewers already know,
 generic adjectives, duplicate definitions, long transitions, implementation
 detail that can move to the appendix, secondary analyses that can move to the

--- a/argus_skill/verticals/research/skills/engineer/venue-format-preflight.md
+++ b/argus_skill/verticals/research/skills/engineer/venue-format-preflight.md
@@ -13,7 +13,13 @@ do not infer rules from another conference.
 
 - Use the official document class, style files, review mode, paper size,
   columns, fonts, bibliography behavior, and anonymity rules.
-- Treat the venue's body limit as a ceiling, not a quota. Never pad to reach a page number or word target; reflow content that exceeds the current limit.
+- Treat the venue's body limit as a compliance ceiling, not a quota imposed by
+  the venue; reflow content that exceeds the current limit.
+- Separately compare the rendered, officially counted body extent with the
+  writing target from `research-paper-playbook.md`. Total PDF pages including
+  excluded end matter do not establish body length. Record the actual extent
+  and target in existing research notes. Use the playbook's principle-led
+  expansion guidance to develop a short body toward its writing target.
 - Include all required sections, disclosures, checklists, and end matter in the
   venue's required order.
 - Resolve every citation and reference; remove placeholders and compilation

--- a/argus_skill/verticals/research/skills/engineer/venue-format-research.md
+++ b/argus_skill/verticals/research/skills/engineer/venue-format-research.md
@@ -14,7 +14,8 @@ Return one recommendation to Manager with:
 - venue and track;
 - why the contribution fits;
 - current deadline;
-- body limit or word limit;
+- body limit or word limit for the exact track and submission type, including
+  which parts of references, appendices, limitations, and ethics count;
 - anonymity model;
 - required sections, disclosures, and end matter;
 - official author-kit URL.

--- a/argus_skill/verticals/research/skills/engineer/venue-paper-drafting.md
+++ b/argus_skill/verticals/research/skills/engineer/venue-paper-drafting.md
@@ -37,7 +37,9 @@ Write down, before any section:
   table that will carry its evidence;
 - the figure and table plan (Figure 1 explains the idea or mechanism; the first
   table carries the main result), and the page budget per section under the
-  venue's limit.
+  venue's limit. Apply "Plan the manuscript length" in
+  `research-paper-playbook.md`: a full-length paper defaults to using nearly all
+  permitted body space, with official counting rules and a section budget.
 
 Assign the complete evidence to roles while planning: **headline** (establishes
 the thesis; may recur where each location has a distinct job), **mechanism**
@@ -56,8 +58,10 @@ vocabulary and never appear in the manuscript.
    mental model, contribution claims. Rough, disposable, written to fix what
    the results must establish.
 2. **Results**, organized by the claims, each cluster closed by a takeaway that
-   states the pattern and its implication. Then **Method** and **Setup**, only
-   as deep as a reader needs to follow and reproduce.
+   states the pattern and its implication. Then **Method**: develop the
+   principle-level analysis from the length plan, explaining the mechanism,
+   assumptions, derivations, and design tradeoffs in depth. **Setup** provides
+   reproducibility detail; it does not replace this reasoning.
 3. **Final introduction**, from a blank page, now that the results stand: every
    claim maps to a results subsection and the preview carries the real
    headline numbers. Draft 0 is reference material, not the starting text.
@@ -68,8 +72,9 @@ vocabulary and never appear in the manuscript.
    contribution, not on a caveat.
 6. **Compression pass** over the whole draft: remove what serves no explicit
    claim, move detail the reader does not need on first pass to the appendix,
-   protect every claim, number, named baseline and limit. A cut of a third is
-   normal.
+   protect every claim, number, named baseline and limit. There is no target
+   reduction fraction. Develop principle-level analysis according to the
+   selected submission type's length target.
 7. **Stranger's read**: the questions in the craft reference, section 11. Fix
    what fails before compiling the final PDF.
 

--- a/argus_skill/verticals/research/skills/research-experiment-playbook.md
+++ b/argus_skill/verticals/research/skills/research-experiment-playbook.md
@@ -61,9 +61,10 @@ not a complete-looking experiment matrix.
    shapes, branches, numerical behavior, and end-to-end wiring, then run a
    known detectable positive control through the same evaluator path.
 6. Develop the method with real models or systems and the strongest
-   same-information baselines required by the claim. Use public or official
-   benchmarks where relevant; small tasks built from explicit executable rules
-   are valid scientific experiments when they isolate the claimed capability.
+   same-information baselines required by the claim. Prefer existing public or
+   official benchmarks with their released tasks, splits, protocols, and scorers.
+   Small custom benchmarks are allowed under the cost-aware benchmark policy
+   below, including as scientific evidence for a scoped mechanism claim.
    Choose models for task competence and claim scope, not release date.
 7. Keep every run reproducible from its code, explicit configuration, command,
    and raw output.
@@ -90,6 +91,62 @@ development panel sized for quick iteration is not the claim-bearing
 evaluation; once method and evaluation settle, run the comparison at the scale
 the claim needs and say in the research notes why that scale is enough.
 
+### Cost-aware benchmark policy
+
+Use established benchmarks by default for broad task-performance claims and
+large-scale evaluation. Small custom benchmarks are allowed when they consume
+no API calls or only a small amount within the existing authorized budget.
+Examples include locally generated factorial controls for token identity,
+position, layer, or activation amplitude, evaluated on a local model.
+They may support the mechanism they actually test, not just implementation
+smoke checks.
+
+Before dispatch, account for the total API calls and tokens across generation,
+labeling, evaluation, judging, and planned repetitions, as well as local compute.
+A small item count alone does not establish low cost. Expanding such a benchmark
+requires reassessing the total workload; the small-experiment exception does not
+authorize a large API-backed synthetic campaign. Existing project-specific
+restrictions, including a ban on paid APIs or custom tasks, still apply.
+
+Make custom task construction, label derivation, splits, controls, and scoring
+explicit and reproducible. Execute the experiments and preserve their actual
+results. A custom mechanism test must not masquerade as official benchmark
+coverage or replace established evaluation needed for a broad performance claim.
+
+### Planner scale assessment after a passing experiment
+
+Reviewer acceptance establishes that the current experiment meets its
+requirements; it does not by itself establish adequate research scale.
+Before advancing to Paper, Planner inspects the accepted results and actual
+configuration in its next normal planning turn. Compare training coverage,
+independent evaluation items, task or template families, model or agent scales,
+repetitions, and uncertainty with the operator's research objective. Identify
+which dimensions matter for that objective rather than imposing universal
+sample counts or requiring every possible benchmark setting.
+
+If coverage or precision is insufficient, stay in Experiment and assign an
+incremental expansion of the existing implementation. Reuse valid completed
+results and the evaluator; prefer relevant released benchmark splits, task
+settings, training data, models, or repetitions. Apply the cost-aware benchmark
+policy to any small custom experiment and its expansion. Do not count repeated
+identical runs as new independent evidence. Make sample counts configurable and validate against the
+selected configuration, not a hard-coded pilot count. A minimum count is not
+an exact-count requirement.
+
+Keep held-out data out of training and method selection. Expanding training
+creates a new checkpoint and comparison with fresh held-out confirmation;
+preserve the earlier results separately rather than silently pooling them.
+Use measured throughput and available resources to size the next run. Surface
+an actual access or budget blocker instead of quietly shrinking the objective.
+
+If scale is sufficient, state the evidence-based rationale in the existing
+research plan and Planner REASON, and request `ADVANCE_TO_STAGE=paper` with the
+writing task. Manager applies the transition. If insufficient, leave that
+field unset and explain the expansion in the task. Repeat this judgment after
+the expanded experiment is reviewed, not by rerunning an unchanged inspection.
+Do not replace this check with a narrower paper claim or a standalone
+validation-only mission.
+
 When the decisive comparison goes against the mechanism, because a matched
 ablation or the strongest same-information baseline wins on fresh evidence,
 the next move is not another variant of the same objective. Return to the
@@ -109,10 +166,10 @@ placeholder, or projected results: not in the runs, not in the research notes, a
 never in a manuscript.
 
 Choose benchmarks that expose the method's mechanism and real advantage rather
-than convenient saturated tasks. A benchmark the project builds itself is part
-of the claim: write down where every label comes from, check that a constant
-answer does not already score well, and make sure the targets it is meant to
-separate are separable on its items before any model is scored on it. Follow surprising positive evidence when it
+than convenient saturated tasks. Inspect the existing benchmark's label
+provenance, shortcut opportunities, and ability to distinguish the claimed
+mechanism; if unsuitable, select another established benchmark or a small
+custom experiment permitted by the cost-aware benchmark policy. Follow surprising positive evidence when it
 reveals a stronger contribution, then confirm it on untouched data. Keep
 relevant losses visible internally, but do not let defensive edge-case coverage
 replace the main result.
@@ -129,8 +186,10 @@ one would need.
 
 ## When the evidence is ready for Paper
 
-Enter Paper when Reviewer judges that credible evidence improves at least one
-scientifically meaningful dimension. Do not require a hard numeric margin,
+Enter Paper after Reviewer accepts the experiment and Planner's post-result
+scale assessment finds its coverage and precision sufficient for the objective.
+The evidence must improve at least one scientifically meaningful dimension.
+Do not require a hard numeric margin,
 wins on every headline metric, or dominance over every strong baseline. Keep
 uncertainty, relevant losses, and tradeoffs visible, and scope the thesis to
 what improved. Manager alone advances the stage.

--- a/argus_skill/verticals/research/skills/research-paper-playbook.md
+++ b/argus_skill/verticals/research/skills/research-paper-playbook.md
@@ -20,6 +20,39 @@ do not become the narrative.
 
 ## How to build the argument
 
+### Plan the manuscript length
+
+For a full-length conference paper, default to a substantive main body that
+uses nearly all of the selected track's permitted space. The official maximum
+is a compliance ceiling, not an official minimum; the near-limit length is our
+writing target. An operator-requested short paper,
+extended abstract, section-only revision, or a track with different length
+norms overrides this default. Never silently switch tracks to fit a short draft.
+
+Before drafting, verify the current official venue, track, and submission type,
+the applicable page or word limit, and what counts toward it. Set a section
+budget aimed at the final allowed body page and calibrate density against
+accepted papers in that same track. Do not infer body length from total PDF
+pages: references, appendices, limitations, and ethics sections count only as
+the official rules specify. If the limit is unknown, resolve it rather than
+assuming eight pages.
+
+Develop the argument toward this target throughout drafting, not only when
+something is missing. Actively expand principle-level analysis: explain why the
+problem has its structure, how the mechanism follows from the assumptions,
+derive the relevant relationships step by step, and explain design choices,
+tradeoffs, boundary cases, and differences from alternative approaches.
+Use worked conceptual examples when they clarify the reasoning.
+
+Experiments support the argument; they are not its organizing structure.
+Interpret results in terms of the mechanism and its predictions instead of
+expanding run chronology, setup inventories, or metric-by-metric reporting.
+Distinguish derivation, proposed explanation, and empirical observation.
+After compilation, compare actual counted body extent with the target and
+continue developing the principle-level explanation where it is still terse.
+Keep the target and actual counted body extent in the existing research notes;
+do not create a new report or validation-only task.
+
 1. Read the research notes in `RESEARCH_NOTES.md`, the selected venue profile, and the current official
    author kit. Before prose, classify the complete evidence as headline,
    mechanism, disambiguating control, scope-changing, or completeness evidence;
@@ -64,7 +97,7 @@ do not become the narrative.
    vector PDF after Introduction, targeting page 2 or 3, and keep the editable
    SVG source. Invoke the drawing component only when a figure is needed;
    reuse an existing suitable figure across writing rounds and prose-only edits.
-9. Compress after expanding: the final pass removes what serves no explicit
+9. Compress after expanding to the manuscript-length target: the final pass removes what serves no explicit
    claim and moves first-pass-unnecessary detail to the appendix while
    protecting every claim, number, named baseline and limit. Then read the
    paper once as a stranger and fix what fails.
@@ -93,14 +126,18 @@ abstract, introduction, or conclusion when the evidence supports a strong claim.
 ## When the draft is ready
 
 The full paper, bibliography, figures, tables, includes, and rendered output are
-present and mutually consistent. Manager alone advances the stage.
+present and mutually consistent. The counted body extent meets the planned
+length target and the main body develops the principles, mechanism, and design
+reasoning in depth. Being below the legal maximum alone does not establish readiness.
+Manager alone advances the stage.
 
 ## Research notes
 
 Replace the research notes at project-root `RESEARCH_NOTES.md`, beginning with
 `# Research notes — Paper stage`. Include only the current manuscript location,
 central thesis, evidence roles and placements,
-venue, and any known issue Review must inspect. Do not create another drafting
+venue, manuscript-length target and actual counted body extent, and any known
+issue Review must inspect. Do not create another drafting
 or format report.
 
 ## When another skill would help

--- a/argus_skill/verticals/research/skills/research-review-playbook.md
+++ b/argus_skill/verticals/research/skills/research-review-playbook.md
@@ -12,6 +12,15 @@ publication-ready, and worth accepting at the selected venue. Judge it against
 strong accepted and best-paper-level work there. Meeting the letter of the
 requirements alone is not enough.
 
+Apply "Plan the manuscript length" in `research-paper-playbook.md` to a full
+paper. Compare its rendered body extent, under the exact track's counting
+rules, with the writing target. Judge the depth of principle-level analysis:
+does the reader understand why the mechanism follows, what the assumptions
+imply, and why the design choices differ from alternatives? Request expansion
+of terse reasoning, derivations, or tradeoffs. Experiments should support this argument, not turn the
+paper into an experiment report. Put actionable expansion requests in the
+existing `paper/REVIEW.md`. Respect an explicit short-paper or partial-edit request.
+
 ## What each reader can consult
 
 What a reader may consult depends on the operation. The fresh-context Narrative

--- a/argus_skill/verticals/research/stages.py
+++ b/argus_skill/verticals/research/stages.py
@@ -82,9 +82,12 @@ STAGE_CHECKLISTS: dict[str, tuple[ChecklistItem, ...]] = {
             statement=(
                 "Implement the selected mechanism and real strong published baselines "
                 "through real entry points. Do not rename a local heuristic after a paper. "
-                "Choose models for task competence and claim scope. Use appropriate "
-                "public or official benchmarks or controlled tasks with labels derived "
-                "from explicit rules, and a real evaluator. Keep "
+                "Choose models for task competence and claim scope. Prefer appropriate "
+                "existing public or official benchmarks with their released tasks, "
+                "splits, protocols, and real evaluators. Small custom benchmarks are "
+                "allowed under the cost-aware benchmark policy in "
+                "research-experiment-playbook.md: no API calls or only a small amount "
+                "within the authorized budget, respecting project-specific restrictions. Keep "
                 "explicit run configuration beside the code and verify the smallest "
                 "faithful path before claim-bearing execution."
             ),
@@ -141,6 +144,11 @@ STAGE_CHECKLISTS: dict[str, tuple[ChecklistItem, ...]] = {
                 "templates cannot explain it; a handful of development items or one model "
                 "family supports only a correspondingly narrow claim. Otherwise improve the "
                 "method or experiment in the current Experiment stage."
+                " After Reviewer accepts the current experiment, Planner must apply "
+                "the post-result scale assessment in research-experiment-playbook.md "
+                "against the operator objective. If insufficient, expand the existing "
+                "experiment under that benchmark policy before requesting Paper; "
+                "a narrower claim does not substitute for that assessment."
             ),
             evidence_hint="claim-bearing comparisons, controls, and direct raw outputs",
         ),

--- a/tests/life/test_planner_terminal_empty_output.py
+++ b/tests/life/test_planner_terminal_empty_output.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from argus_skill.core.event_catalog import EventType
 from argus_skill.core.models import RunnerResult
 from argus_skill.core.role_decision import encode_role_decision
@@ -880,6 +882,87 @@ def test_nonterminal_planning_replays_unassessed_current_stage_review_first(
         and event.get("recovered_item_id") == item.id
         for event in sink.events
     )
+
+
+@pytest.mark.parametrize("scale_sufficient", [False, True])
+def test_reviewed_experiment_reaches_planner_before_paper(
+    tmp_path: Path, monkeypatch, scale_sufficient: bool,
+) -> None:
+    from argus_skill.skills.stage_machine import current_stage
+    from argus_skill.skills.vertical_select import persist_vertical
+
+    target = "paper" if scale_sufficient else "experiment"
+    title = "Write the paper" if scale_sufficient else "Expand released task coverage"
+
+    class ScalePlannerRunner(_EmptyPlannerThenManagerRunner):
+        def run_exec(self, *, prompt, options, run_label, resume_thread_id=None):
+            assert run_label.startswith("planner.cycle")
+            self.planner_calls += 1
+            assert "Post-result experiment scale assessment" in prompt
+            return RunnerResult(
+                exit_code=0,
+                agent_messages=["\n".join([
+                    "PROJECT_DONE=false",
+                    "REASON=Reviewed coverage is sufficient for writing."
+                    if scale_sufficient
+                    else "REASON=Reviewed coverage needs more official task settings.",
+                    f"ADVANCE_TO_STAGE={target}",
+                    "TASK_KEY=scale-followup",
+                    f"TASK_TITLE={title}",
+                    f"TASK_OBJECTIVE={title} using the existing implementation and official benchmark.",
+                    "TASK_HYPOTHESIS=The next step addresses the reviewed coverage.",
+                    "TASK_GOAL_CONTRIBUTION=Support the operator research objective.",
+                    "TASK_EXPECTED_REGRESSIONS=Preserve accepted raw results.",
+                    "TASK_DECISION_RULE=Use coverage and precision for the objective.",
+                    "TASK_ACCEPTANCE_CHECK=Review direct artifacts against the objective.",
+                    "TASK_SCOPE=bounded",
+                ])],
+                stdout_lines=[],
+                stderr_lines=[],
+            )
+
+    supervisor, backend, _sink = _make_supervisor(
+        tmp_path, monkeypatch, terminal_stage_done=False,
+        backend=ScalePlannerRunner(),
+    )
+    project = Path(supervisor.config.project_worktree)
+    persist_vertical(project, "research", workflow_mode="staged")
+    state_path = project / ".argus" / "PIPELINE_STATE.json"
+    state = json.loads(state_path.read_text())
+    state["current_stage"] = "experiment"
+    state_path.write_text(json.dumps(state))
+    item = supervisor.memory.backlog.add(BacklogItem.new(
+        title="Run the current experiment",
+        objective="Evaluate the existing official task panel.",
+        tags=["planner", "scope:bounded"],
+    ))
+    mission_path = create_mission_context(
+        life_dir=supervisor.memory.root, mission_id=item.id,
+        stage="experiment", objective=item.objective, scope="bounded",
+    )
+    record_reviewed_handoff(
+        mission_context_path=mission_path, round_index=1,
+        engineer_summary="The configured panel is complete.",
+        review=SimpleNamespace(
+            status="done", reason="The current comparison is accepted.",
+            next_action="", operator_question="",
+        ),
+        checkpoint_path=None,
+    )
+    supervisor.memory.backlog.mark_done(item.id, outcome={
+        "execution_status": "completed",
+        "review_status": "done",
+        "stage_certification": "not_assessed",
+        "interruption_kind": "none",
+        "resumable": False,
+    })
+
+    supervisor._plan_next_work()
+
+    assert backend.planner_calls == 1
+    assert backend.manager_calls == 0
+    assert current_stage(project) == target
+    assert [row.title for row in supervisor.memory.backlog.pending()] == [title]
 
 
 def test_newer_replan_review_blocks_older_stage_replay(

--- a/tests/manager/test_experiment_scale_assessment.py
+++ b/tests/manager/test_experiment_scale_assessment.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from argus_skill.core.models import ReviewDecision
+from argus_skill.life.supervisor._planning_cycle_enqueue import (
+    _apply_planner_stage_request,
+)
+from argus_skill.manager import Manager
+from argus_skill.skills.stage_machine import current_stage
+from argus_skill.skills.vertical_select import persist_vertical
+from argus_skill.verticals.research.prompt_policy import render_role_prompt_fragment
+from argus_skill.verticals.research.stages import STAGE_CHECKLISTS
+
+
+def _experiment_manager(tmp_path, *, workflow_mode="staged"):
+    state_root = tmp_path / "state"
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    persist_vertical(state_root, "research", workflow_mode=workflow_mode)
+    state_path = state_root / ".argus" / "PIPELINE_STATE.json"
+    state = json.loads(state_path.read_text())
+    state["current_stage"] = "experiment"
+    state_path.write_text(json.dumps(state))
+    return Manager(
+        project_root=state_root,
+        execution_workdir=workdir,
+        runner=object(),
+    ), state_root, workdir
+
+
+@pytest.mark.parametrize("stage_closing", [False, True])
+def test_passing_experiment_waits_for_planner_even_on_fast_path(
+    tmp_path, stage_closing,
+):
+    manager, root, _workdir = _experiment_manager(tmp_path)
+    decision = manager.decide_stage_transition(
+        review=ReviewDecision(status="done", reason="The configured run passed.", next_action=""),
+        stage_closing=stage_closing,
+        continuous_objective="Develop a broadly supported method on existing benchmarks.",
+        run_exec=lambda _prompt: pytest.fail("scale assessment must reach Planner first"),
+    )
+
+    assert decision.action == "hold"
+    assert decision.diagnostic == "experiment_scale_assessment_required"
+    assert current_stage(root) == "experiment"
+
+
+def test_expansion_plan_does_not_advance_but_sufficient_scale_can(tmp_path):
+    manager, root, workdir = _experiment_manager(tmp_path)
+    review = ReviewDecision(status="done", reason="The configured run passed.", next_action="")
+    decision = manager.decide_stage_transition(
+        review=review,
+        planner_verdict=SimpleNamespace(
+            advance_to_stage="",
+            reason="Expand to the remaining released task settings.",
+        ),
+        run_exec=lambda _prompt: pytest.fail("an expansion plan must stay in Experiment"),
+    )
+    assert decision.action == "hold"
+    assert current_stage(root) == "experiment"
+
+    # The normal Planner request is the existing Manager-owned transition route.
+    _apply_planner_stage_request(
+        state_root=root,
+        evidence_root=workdir,
+        requested_stage="paper",
+        reason="Reviewed expanded evidence covers the objective with adequate precision.",
+    )
+    assert current_stage(root) == "paper"
+
+
+def test_manager_receives_planner_adequacy_rationale(tmp_path):
+    manager, root, _workdir = _experiment_manager(tmp_path)
+    prompts = []
+
+    def decide(prompt):
+        prompts.append(prompt)
+        return SimpleNamespace(
+            last_agent_message=(
+                '{"action":"advance","target_stage":"paper",'
+                '"reason":"Reviewed evidence and Planner scale assessment are sufficient."}'
+            )
+        )
+
+    decision = manager.decide_stage_transition(
+        review=ReviewDecision(status="done", reason="Expanded comparison accepted.", next_action=""),
+        planner_verdict=SimpleNamespace(
+            advance_to_stage="paper",
+            reason="Released task families and repeated runs cover the objective.",
+        ),
+        run_exec=decide,
+    )
+    assert decision.action == "advance"
+    assert current_stage(root) == "paper"
+    assert "Released task families" in prompts[0]
+
+
+def test_direct_experiment_request_is_not_forced_into_paper(tmp_path):
+    manager, root, _workdir = _experiment_manager(tmp_path, workflow_mode="direct")
+    decision = manager.decide_stage_transition(
+        review=ReviewDecision(status="done", reason="The requested experiment is complete.", next_action=""),
+        mission_scope="bounded",
+        stage_closing=True,
+        run_exec=lambda _prompt: pytest.fail("direct completion should stay deterministic"),
+    )
+    assert decision.action == "complete"
+    assert current_stage(root) == "experiment"
+
+
+def test_standalone_staged_work_without_planner_keeps_existing_transition(tmp_path):
+    manager, root, _workdir = _experiment_manager(tmp_path)
+    decision = manager.decide_stage_transition(
+        review=ReviewDecision(status="done", reason="The experiment is complete.", next_action=""),
+        mission_scope="bounded",
+        stage_closing=True,
+        run_exec=lambda _prompt: pytest.fail("standalone transition should stay deterministic"),
+    )
+    assert decision.action == "advance"
+    assert current_stage(root) == "paper"
+
+
+def test_planner_scale_policy_uses_existing_benchmarks_without_new_mission():
+    prompt = render_role_prompt_fragment(
+        role="planner",
+        operation="continuous",
+        stage="experiment",
+        scope="",
+        project_root=None,
+    )
+    for required in (
+        "After Reviewer accepts",
+        "training and evaluation coverage",
+        "incremental scale-up",
+        "existing benchmarks",
+        "small custom benchmarks are allowed",
+        "no API calls or only a small amount",
+        "reassess total cost when expanding",
+        "Respect stricter project-specific restrictions",
+        "ADVANCE_TO_STAGE=paper",
+        "Do not schedule a separate inspection mission",
+    ):
+        assert required in prompt
+    checklist = " ".join(item.statement for item in STAGE_CHECKLISTS["experiment"])
+    assert "Planner must apply" in checklist
+    assert "Small custom benchmarks are allowed" in checklist
+    assert "cost-aware benchmark policy" in checklist
+    paper_prompt = render_role_prompt_fragment(
+        role="planner",
+        operation="continuous",
+        stage="paper",
+        scope="",
+        project_root=None,
+    )
+    assert "## Post-result experiment scale assessment" not in paper_prompt
+
+
+def test_small_custom_benchmarks_are_scientific_evidence_with_cost_accounting():
+    playbook = (
+        Path(__file__).resolve().parents[2]
+        / "argus_skill/verticals/research/skills/research-experiment-playbook.md"
+    )
+    text = " ".join(playbook.read_text(encoding="utf-8").split())
+    for required in (
+        "Small custom benchmarks are allowed",
+        "scientific evidence for a scoped mechanism claim",
+        "generation, labeling, evaluation, judging, and planned repetitions",
+        "as well as local compute",
+        "does not authorize a large API-backed synthetic campaign",
+        "project-specific restrictions",
+        "label derivation, splits, controls, and scoring",
+        "must not masquerade as official benchmark coverage",
+    ):
+        assert required in text
+    assert "Do not invent a benchmark or synthetic replacement tasks" not in text

--- a/tests/test_paper_length_and_citation_quotas.py
+++ b/tests/test_paper_length_and_citation_quotas.py
@@ -6,6 +6,9 @@ second-to-last page. Both punished short, complete papers and rewarded padding.
 The venue page count is a *ceiling*; citation sufficiency is proportional to
 what the paper claims. What must still fail is fabrication, over-length, and
 wrong templates.
+
+Full papers nevertheless have a near-limit writing target, developed through
+principle-level analysis rather than an experiment report or a numerical gate.
 """
 from __future__ import annotations
 
@@ -86,10 +89,76 @@ def test_over_length_is_still_enforced() -> None:
     assert "reflow content" in text
 
 
-def test_padding_is_explicitly_discouraged() -> None:
+def test_preflight_routes_expansion_to_the_writing_policy() -> None:
     text = _read("engineer/venue-format-preflight.md")
 
-    assert "Never pad to reach a page number" in text
+    assert "principle-led" in text
+    assert "toward its writing target" in text
+
+
+def test_full_paper_length_target_is_distinct_from_official_limit() -> None:
+    text = " ".join(_read("research-paper-playbook.md").split())
+
+    for required in (
+        "uses nearly all",
+        "not an official minimum",
+        "Never silently switch tracks",
+        "Do not infer body length from total PDF",
+        "If the limit is unknown",
+        "Actively expand principle-level analysis",
+        "Distinguish derivation, proposed explanation, and empirical observation",
+        "existing research notes",
+    ):
+        assert required in text
+
+
+@pytest.mark.parametrize("role,operation", [
+    ("engineer", "mission"),
+    ("reviewer", "evaluate"),
+])
+def test_live_paper_prompts_carry_length_policy(role: str, operation: str) -> None:
+    from argus_skill.verticals.research.prompt_policy import render_role_prompt_fragment
+
+    text = render_role_prompt_fragment(
+        role=role,
+        operation=operation,
+        stage="paper" if role == "engineer" else "review",
+        scope="" if role == "engineer" else "final_submission",
+        project_root=None,
+    )
+    assert "research-paper-playbook.md" in text
+    assert "principle-level analysis" in text
+    assert "derivations, and design tradeoffs" in text
+    assert "technically complete" not in text
+    assert "experiment report" in text
+    assert "not total PDF pages" in text
+    assert "short-paper and partial-edit requests" in text
+    assert "full unused body page" not in text
+    assert "shorter-paper exception" not in text
+
+
+def test_paper_skills_favor_principle_led_expansion() -> None:
+    for relative in (
+        "research-paper-playbook.md",
+        "research-review-playbook.md",
+        "engineer/venue-paper-drafting.md",
+        "engineer/references/paper-writing-craft.md",
+    ):
+        text = " ".join(_read(relative).split())
+        assert "principle-level analysis" in text
+        assert "technically complete" not in text
+        assert "full unused body page" not in text
+        assert "shorter-paper exception" not in text
+
+
+def test_compression_has_no_fixed_reduction_target() -> None:
+    for relative in (
+        "engineer/venue-paper-drafting.md",
+        "engineer/references/paper-writing-craft.md",
+    ):
+        text = " ".join(_read(relative).split())
+        assert "a cut of a third is normal" not in text
+        assert "target reduction fraction" in text
 
 
 # -- the layout reviewer's underfill signal ---------------------------------


### PR DESCRIPTION
## Summary
- Give full-length papers a venue- and track-aware near-limit body target, emphasizing mechanisms, derivations, and design tradeoffs rather than experiment-report narration. Respect short-paper and partial-edit requests and remove fixed-fraction compression advice.
- Keep accepted experiments in staged research campaigns open until Planner assesses training and evaluation scale against the operator objective. Reuse the existing Manager-owned stage-request path to advance when sufficient, or schedule incremental expansion when insufficient; do not add a separate inspection mission.
- Prefer established benchmarks while allowing small custom mechanism experiments with no or low API consumption within existing authorization. Reassess total cost during expansion, preserve stricter project restrictions, and keep held-out evidence separate when training changes.

## Behavior boundaries
- Preserve standalone staged and direct-request completion behavior.
- Preserve official page ceilings and advisory-only layout underfill handling; no fixed sample quotas or mandatory one-page-short checks.
- Do not deploy runtime changes, restart daemons, or modify existing research projects or manuscripts.

## Validation
152 targeted regression tests passed across Planner lifecycle, Manager stage transitions, research checklists, manuscript policy, venue layout, and prompt-budget coverage. Includes end-to-end Planner scheduling cases for both expansion and advancement.